### PR TITLE
Fix broken build: bump terminal-view compileSdk to 37

### DIFF
--- a/terminal-view/build.gradle
+++ b/terminal-view/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven-publish'
 
 android {
     namespace "com.termux.view"
-    compileSdkVersion 36
+    compileSdkVersion 37
 
     dependencies {
         implementation libs.androidx.annotation


### PR DESCRIPTION
## Summary

Fixes #116

`terminal-emulator` was bumped to compileSdk 37 but `terminal-view`, which depends on it, was still on 36, so the AAR metadata check fails for every consumer and **master does not build at all**:

```
Dependency ':terminal-emulator' requires libraries and applications that
depend on it to compile against version 37 or later ...
:terminal-view is currently compiled against android-36.
```

One-line change: `compileSdkVersion 36` → `37`, matching `:app` and `terminal-emulator`.

## Test plan

- [x] `./gradlew assembleDebug` on a clean checkout of this branch: BUILD SUCCESSFUL (fails without the patch).