### PR TITLE
Fix VNC port check, disk/ISO extension matching, and audiodev id race

### DIFF
--- a/app/src/main/java/com/vectras/vm/VMManager.java
+++ b/app/src/main/java/com/vectras/vm/VMManager.java
@@ -46,6 +46,7 @@ import org.jetbrains.annotations.Contract;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -661,11 +662,13 @@ public class VMManager {
         return "";
     }
 
+    private static final List<String> DISK_FILE_FORMATS = Arrays.asList("qcow2", "img", "vhd", "vhdx", "vdi", "qcow", "vmdk", "vpc");
+
     public static boolean isADiskFile(@NonNull String _filepath) {
         if (_filepath.contains(".")) {
             String _getFileName = Objects.requireNonNull(Uri.parse(_filepath).getLastPathSegment()).toLowerCase();
             String _getFileFormat = _getFileName.substring(_getFileName.lastIndexOf(".") + 1);
-            return "qcow2,img,vhd,vhdx,vdi,qcow,vmdk,vpc".contains(_getFileFormat);
+            return DISK_FILE_FORMATS.contains(_getFileFormat);
         }
         return false;
     }
@@ -693,7 +696,7 @@ public class VMManager {
         if (_filepath.contains(".")) {
             String _getFileName = Objects.requireNonNull(Uri.parse(_filepath).getLastPathSegment()).toLowerCase();
             String _getFileFormat = _getFileName.substring(_getFileName.lastIndexOf(".") + 1);
-            return "iso".contains(_getFileFormat);
+            return "iso".equals(_getFileFormat);
         }
         return false;
     }
@@ -1241,7 +1244,8 @@ public class VMManager {
     }
 
     public static String addAudioDevWav(String vmID, String env) {
-        final String audioDevParam = ",audiodev=audiodev" + System.currentTimeMillis() + " -audiodev wav,id=audiodev" + System.currentTimeMillis() + ",out.frequency=48000,path=" + VmFileManager.getAudioRaw(VectrasApp.getContext(), vmID);
+        final long audioDevId = System.currentTimeMillis();
+        final String audioDevParam = ",audiodev=audiodev" + audioDevId + " -audiodev wav,id=audiodev" + audioDevId + ",out.frequency=48000,path=" + VmFileManager.getAudioRaw(VectrasApp.getContext(), vmID);
         String result = env;
         if (env.startsWith("-device hda-duplex ") || env.contains(" -device hda-duplex ") || env.endsWith(" -device hda-duplex")) {
             result = result.replaceFirst(" -device hda-duplex", " -device hda-duplex" + audioDevParam);

--- a/app/src/main/java/com/vectras/vm/main/core/MainStartVM.java
+++ b/app/src/main/java/com/vectras/vm/main/core/MainStartVM.java
@@ -275,7 +275,7 @@ public class MainStartVM {
         }
 
         if (MainSettingsManager.getVncExternal(context) &&
-                NetworkUtils.isPortOpen("localhost", Config.defaultVNCPort + Config.defaultVNCPort, 500)) {
+                NetworkUtils.isPortOpen("localhost", 5900 + Config.defaultVNCPort, 500)) {
             DialogUtils.twoDialog(context, context.getString(R.string.problem_has_been_detected),
                     context.getString(R.string.the_vnc_server_port_you_set_is_currently_in_use_by_other),
                     context.getString(R.string.go_to_settings),


### PR DESCRIPTION
## Summary

Fixes #117 — three small, independent correctness fixes (one commit each):

1. **VNC port-in-use check** (`MainStartVM.java`): probe `5900 + Config.defaultVNCPort` instead of `defaultVNCPort + defaultVNCPort`. `defaultVNCPort` holds the QEMU display number, so the old check probed port 2 with the default display of 1 and the warning could never fire correctly.
2. **Disk/ISO detection** (`VMManager.java`): compare extensions against an exact set instead of `String.contains`, so `.c` / `.o` / `.so` files are no longer treated as disk images or ISOs in the ROM export and VM creation flows.
3. **audiodev id** (`VMManager.java`): reuse a single timestamp for `-device ...,audiodev=audiodevX` and `-audiodev wav,id=audiodevX`; two independent `System.currentTimeMillis()` calls could straddle a millisecond and make QEMU fail to start.

## Test plan

- [x] `./gradlew assembleDebug` succeeds (on top of #122, which fixes the currently broken master build).
- [x] Behavior reasoning cross-checked against `ExternalVNCSettingsActivity` (`display + 5900`) and `StartVM.java:168/176` (single-timestamp pattern).