### PR TITLE
Add secrets-free PR Build workflow as a merge gate

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,81 @@
+# Merge gate: every PR and push to master must build.
+# This workflow needs no secrets (a placeholder google-services.json is
+# generated when GOOGLE_SERVICES_JSON is unavailable, e.g. for fork PRs),
+# so it also runs for external contributors.
+# CI gates merges; it never closes issues by itself.
+
+name: PR Build
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: pr-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Create google-services.json
+        run: |
+          if [ -n "${{ secrets.GOOGLE_SERVICES_JSON }}" ]; then
+            echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > app/google-services.json
+          else
+            cat > app/google-services.json <<'JSON'
+          {
+            "project_info": {
+              "project_number": "123456789000",
+              "project_id": "vectras-ci-placeholder",
+              "storage_bucket": "vectras-ci-placeholder.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:123456789000:android:0000000000000000",
+                  "android_client_info": {
+                    "package_name": "com.vectras.vm"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [
+                  {
+                    "current_key": "AIzaSyA0000000000000000000000000000000000"
+                  }
+                ],
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": []
+                  }
+                }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          JSON
+            echo "GOOGLE_SERVICES_JSON secret not available; using placeholder google-services.json"
+          fi
+
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload Debug APK as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary

Fixes #119

Adds `.github/workflows/pr-build.yml`:

- triggers on every `pull_request` and on pushes to `master`;
- needs **no secrets**: when `GOOGLE_SERVICES_JSON` is unavailable (fork PRs) it generates a placeholder `google-services.json`, so external contributors get real build feedback;
- builds `assembleDebug` and uploads the APK as an artifact;
- cancels superseded runs via `concurrency`.

The existing release/Telegram workflow (`android.yml`) is untouched.

Note: this check will stay red until #122 merges, because master currently does not build (#116) — which is exactly the kind of breakage this gate is meant to catch.

## Test plan

- [x] Workflow YAML parses; heredoc indentation verified after YAML stripping.
- [x] The exact placeholder `google-services.json` content was used for a local `assembleDebug` run: BUILD SUCCESSFUL.
- [ ] Once merged: green run on this workflow for subsequent PRs.