### PR TITLE
Allow overriding release signing via gitignored keystore.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ captures/
 # Uncomment the following lines if you do not want to check your keystore files in.
 #*.jks
 #*.keystore
+keystore.properties
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,21 @@ plugins {
     id 'com.google.android.gms.oss-licenses-plugin'
 }
 
+// Optional signing override: put a keystore.properties file at the repo root
+// (gitignored) with storeFile / storePassword / keyAlias / keyPassword to sign
+// with a private keystore, e.g. after rotating the public one. Without that
+// file the historical values below are used, so existing local and CI builds
+// are unaffected.
+def keystoreProps = new Properties()
+def keystorePropsFile = rootProject.file('keystore.properties')
+if (keystorePropsFile.exists()) {
+    keystorePropsFile.withInputStream { keystoreProps.load(it) }
+}
+def vectrasStoreFile = keystoreProps['storeFile'] ?: '../vectras.jks'
+def vectrasStorePassword = keystoreProps['storePassword'] ?: '856856'
+def vectrasKeyAlias = keystoreProps['keyAlias'] ?: 'vectras'
+def vectrasKeyPassword = keystoreProps['keyPassword'] ?: '856856'
+
 android {
     namespace 'com.vectras.vm'
     compileSdk = 37
@@ -24,16 +39,16 @@ android {
 
     signingConfigs {
         debug {
-            storeFile file('../vectras.jks')
-            keyAlias 'vectras'
-            storePassword '856856'
-            keyPassword '856856'
+            storeFile file(vectrasStoreFile)
+            keyAlias vectrasKeyAlias
+            storePassword vectrasStorePassword
+            keyPassword vectrasKeyPassword
         }
         release {
-            storeFile file('../vectras.jks')
-            keyAlias 'vectras'
-            storePassword '856856'
-            keyPassword '856856'
+            storeFile file(vectrasStoreFile)
+            keyAlias vectrasKeyAlias
+            storePassword vectrasStorePassword
+            keyPassword vectrasKeyPassword
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #120, and is step 2 of the rotation plan in #121 (rotation itself needs a maintainer decision, so that issue stays open).

`app/build.gradle` now reads an optional gitignored `keystore.properties` at the repo root:

```properties
storeFile=/path/to/keystore.jks
storePassword=...
keyAlias=...
keyPassword=...
```

Without the file the historical values are used unchanged, so current local builds and CI are unaffected. Once a private keystore exists, rotating the leaked signing key (#121) becomes a pure configuration change — including in CI by generating the file from an Actions secret.

## Test plan

- [x] `assembleDebug` + `assembleRelease` with no `keystore.properties`: BUILD SUCCESSFUL (fallback path).
- [x] `assembleRelease` with a `keystore.properties` pointing at the same keystore: BUILD SUCCESSFUL.
- [x] Negative test: wrong password in `keystore.properties` fails the build with "keystore password was incorrect", proving the file is actually read.