### PR TITLE
Fix invalid QEMU -drive media=cdromdrive1 parameter

### DIFF
--- a/app/src/main/java/com/vectras/vm/StartVM.java
+++ b/app/src/main/java/com/vectras/vm/StartVM.java
@@ -282,8 +282,10 @@ public class StartVM {
                         cdrom = "-cdrom";
                         cdrom += " '" + vmConfigs.imgCdrom + "'";
                     } else {
+                        // QEMU only accepts media=disk|cdrom, so the drive must be
+                        // defined with if=none plus an id instead of media=cdromdriveN.
                         cdrom = "-drive";
-                        cdrom += " media=cdromdrive1";
+                        cdrom += " if=none,id=cdromdrive1,format=raw,media=cdrom";
                         cdrom += ",file='" + vmConfigs.imgCdrom + "'";
                     }
                 }
@@ -303,8 +305,9 @@ public class StartVM {
                     cdromParams += " if=none,id=cdromdrive1,format=raw,media=cdrom,file='" + vmConfigs.cdrom1 + "'";
                 } else {
                     cdromParams = "-drive";
-                    cdromParams += " media=cdromdrive1";
+                    cdromParams += " if=none,id=cdromdrive1,format=raw,media=cdrom";
                     cdromParams += ",file='" + vmConfigs.cdrom1 + "'";
+                    cdromParams += " -device ide-cd,drive=cdromdrive1";
                 }
                 params.add(cdromParams);
             }


### PR DESCRIPTION
## Problem

`StartVM.env()` builds the secondary CD-ROM parameters as:

```
-drive media=cdromdrive1,file='...'
```

QEMU's `-drive media=` option only accepts `disk` or `cdrom`. With `media=cdromdrive1` QEMU exits immediately with `Invalid media mode`, so:

- Any x86/x86_64/PPC VM with a secondary CD-ROM (`cdrom1`) set could **never boot** (it always hit this branch).
- Any x86/x86_64/PPC VM with a primary ISO *and* `-cdrom ` inside the extra params also hit the broken branch.

The ARM64 path already used the correct `if=none,id=...,media=cdrom` form — this makes the x86 path match it.

## Fix

```
-drive if=none,id=cdromdrive1,format=raw,media=cdrom,file='...' -device ide-cd,drive=cdromdrive1
```

The drive is defined with `if=none` plus an explicit id and then attached with an `ide-cd` device, which is the supported way to add a second optical drive.

## Impact

VMs with two CD-ROM drives (or ISO + `-cdrom` in extra params) on x86/x86_64/PPC boot again instead of failing with the generic error dialog.