### PR TITLE
Close the QMP LocalSocket and fix inverted retry condition

### DIFF
--- a/app/src/main/java/com/vectras/qemu/utils/QmpClient.java
+++ b/app/src/main/java/com/vectras/qemu/utils/QmpClient.java
@@ -49,7 +49,7 @@ public class QmpClient {
 			sendRequest(out, QmpClient.requestCommandMode);
 			while(true){
                 response = getResponse(in);
-                if(response == null || response.equals("") || trial <10)
+                if(response == null || response.equals("") || trial >= 10)
 				    break;
 
                 Thread.sleep(1000);
@@ -82,6 +82,13 @@ public class QmpClient {
 			} catch (IOException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
+			}
+			if (localSocket != null) {
+				try {
+					localSocket.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
 			}
 
 		}


### PR DESCRIPTION
## Problem

Two bugs in `QmpClient.sendCommand()`, which runs for **every** QMP interaction (mouse clicks, key presses, status polls, pause/resume/power/screenshot actions):

### 1. LocalSocket FD leak

The `LocalSocket` opened per command was never closed in the `finally` block — only the `PrintWriter`/`BufferedReader` wrappers were. `LocalSocket.close()` is what releases the underlying filesystem-socket FDs. FDs accumulate across a long VM session until the process hits its limit and throws `Too many open files`.

### 2. Dead retry loop (inverted condition)

```java
if (response == null || response.equals("") || trial < 10)
    break;
```

`trial` starts at 0, so `trial < 10` is always true on the first check — the loop always breaks immediately and the intended 1-second retry/sleep is unreachable. The command loop below it correctly uses `trial < 10` as its *continue* condition; the handshake loop needed `>= 10` as its *break* condition.

## Fix

- Close `localSocket` in the `finally` block.
- Change the handshake break condition to `trial >= 10` so a slow QEMU handshake is actually retried up to 10 times instead of never.

## Impact

Eliminates a guaranteed FD leak that crashes long-running sessions, and makes the QMP capabilities handshake retries actually work.