### PR TITLE
Fix ACPI fallback path returning audio.raw

### DIFF
--- a/app/src/main/java/com/vectras/vm/manager/VmFileManager.java
+++ b/app/src/main/java/com/vectras/vm/manager/VmFileManager.java
@@ -252,9 +252,9 @@ public class VmFileManager {
 
     // Find the location of the aml file if getExternalCacheDir() is null.
     public static String findCompiledBatteryAcpi(Context context, String vmId) {
-        String audioFilePath = VmFileManager.getInternalTempPath(context, vmId, COMPILED_BATERRY_ACPI_FILE_NAME);
-        if (FileUtils.isFileExists(audioFilePath)) return audioFilePath;
-        return VmFileManager.getAudioRaw(context, vmId);
+        String amlFilePath = VmFileManager.getInternalTempPath(context, vmId, COMPILED_BATERRY_ACPI_FILE_NAME);
+        if (FileUtils.isFileExists(amlFilePath)) return amlFilePath;
+        return VmFileManager.getCompiledBatteryAcpi(context, vmId);
     }
 
     public static String getCompiledWifiCardAcpi(Context context, String vmId) {
@@ -263,9 +263,9 @@ public class VmFileManager {
 
     // Find the location of the aml file if getExternalCacheDir() is null.
     public static String findCompiledWifiCardAcpi(Context context, String vmId) {
-        String audioFilePath = VmFileManager.getInternalTempPath(context, vmId, COMPILED_WIFI_CARD_ACPI_FILE_NAME);
-        if (FileUtils.isFileExists(audioFilePath)) return audioFilePath;
-        return VmFileManager.getAudioRaw(context, vmId);
+        String amlFilePath = VmFileManager.getInternalTempPath(context, vmId, COMPILED_WIFI_CARD_ACPI_FILE_NAME);
+        if (FileUtils.isFileExists(amlFilePath)) return amlFilePath;
+        return VmFileManager.getCompiledWifiCardAcpi(context, vmId);
     }
 
     public static boolean removeAudioRaw(Context context, String vmId) {


### PR DESCRIPTION
## Problem

`findCompiledBatteryAcpi()` and `findCompiledWifiCardAcpi()` in `VmFileManager` were copy-pasted from `findAudioRaw()` and their **fallback branch still returned the audio.raw path**:

```java
public static String findCompiledBatteryAcpi(Context context, String vmId) {
    String audioFilePath = VmFileManager.getInternalTempPath(context, vmId, COMPILED_BATERRY_ACPI_FILE_NAME);
    if (FileUtils.isFileExists(audioFilePath)) return audioFilePath;
    return VmFileManager.getAudioRaw(context, vmId);   // WRONG: audio.raw
}
```

The fallback runs exactly when the compiled AML is missing from the internal temp dir, so the generated `-acpitable file=` QEMU argument pointed at a raw audio dump. QEMU rejects the invalid ACPI table, meaning **battery and Wi-Fi emulation silently broke in the degraded-storage case these helpers exist for**.

Contrast with `findScreenshotPpm()` a few lines above, which correctly falls back to the internal path — this just makes the two ACPI helpers follow the same pattern.

## Fix

Return the compiled AML paths (`getCompiledBatteryAcpi` / `getCompiledWifiCardAcpi`) instead of `getAudioRaw`, and rename the misleading local variable `audioFilePath` → `amlFilePath`.