### PR TITLE
Enforce Zip Slip guard in the Uri-based extract() overload

### DIFF
--- a/app/src/main/java/com/vectras/vm/utils/ZipUtils.java
+++ b/app/src/main/java/com/vectras/vm/utils/ZipUtils.java
@@ -175,57 +175,59 @@ public class ZipUtils {
                 buffer = new byte[128 * 1024];
 
             while ((entry = zin.getNextEntry()) != null) {
-                File newFile = new File(outdir, entry.getName());
+                if (isAllowExtract(entry, destDir)) {
+                    File newFile = new File(outdir, entry.getName());
 
-                if (entry.isDirectory()) {
-                    newFile.mkdirs();
-                    continue;
-                }
+                    if (entry.isDirectory()) {
+                        newFile.mkdirs();
+                        continue;
+                    }
 
-                newFile.getParentFile().mkdirs();
+                    newFile.getParentFile().mkdirs();
 
-                FileOutputStream fos = new FileOutputStream(newFile);
-                int len;
-                long fileExtracted = 0;
+                    FileOutputStream fos = new FileOutputStream(newFile);
+                    int len;
+                    long fileExtracted = 0;
 
-                long lastProgress = -1;
-                while ((len = zin.read(buffer)) > 0) {
-                    fos.write(buffer, 0, len);
-                    fileExtracted += len;
-                    extractedSize += len;
-                    if (totalSize > 0) {
-                        long progress = extractedSize * 100 / totalSize;
+                    long lastProgress = -1;
+                    while ((len = zin.read(buffer)) > 0) {
+                        fos.write(buffer, 0, len);
+                        fileExtracted += len;
+                        extractedSize += len;
+                        if (totalSize > 0) {
+                            long progress = extractedSize * 100 / totalSize;
 
-                        if (progress > lastProgress) {
-                            lastProgress = progress;
-                            updateStatus(
-                                    statusTextView,
-                                    progressBar,
-                                    (progress == 0 || progress > 100 ?
-                                            context.getString(R.string.importing) :
-                                            context.getString(R.string.completed) + " " + progress + "%")
-                                            + "\n" + context.getString(R.string.please_stay_here),
-                                    (int) progress
-                            );
-                        }
-                    } else {
-                        if (extractedSize > lastProgress + (1024 * 1024) || lastProgress < 1) {
-                            lastProgress = extractedSize;
-                            long mb = extractedSize / (1024 * 1024);
-                            updateStatus(
-                                    statusTextView,
-                                    progressBar,
-                                    (mb == 0 ?
-                                            context.getString(R.string.importing) :
-                                            context.getString(R.string.completed) + " " + NumberUtils.getFormatSizeFromMB(mb))
-                                            + "\n" + context.getString(R.string.please_stay_here),
-                                    0
-                            );
+                            if (progress > lastProgress) {
+                                lastProgress = progress;
+                                updateStatus(
+                                        statusTextView,
+                                        progressBar,
+                                        (progress == 0 || progress > 100 ?
+                                                context.getString(R.string.importing) :
+                                                context.getString(R.string.completed) + " " + progress + "%")
+                                                + "\n" + context.getString(R.string.please_stay_here),
+                                        (int) progress
+                                );
+                            }
+                        } else {
+                            if (extractedSize > lastProgress + (1024 * 1024) || lastProgress < 1) {
+                                lastProgress = extractedSize;
+                                long mb = extractedSize / (1024 * 1024);
+                                updateStatus(
+                                        statusTextView,
+                                        progressBar,
+                                        (mb == 0 ?
+                                                context.getString(R.string.importing) :
+                                                context.getString(R.string.completed) + " " + NumberUtils.getFormatSizeFromMB(mb))
+                                                + "\n" + context.getString(R.string.please_stay_here),
+                                        0
+                                );
+                            }
                         }
                     }
+                    fos.close();
+                    zin.closeEntry();
                 }
-                fos.close();
-                zin.closeEntry();
             }
             //zin also closes the inputstream2
             zin.close();


### PR DESCRIPTION
## Problem

`ZipUtils` has two `extract()` overloads. The `String`-based one correctly wraps every entry in `isAllowExtract(entry, destDir)` (canonicalize + reject `..` escapes). The **`Uri`-based one only used that check in the optional size-calculation pass — never in the actual extraction loop**:

```java
while ((entry = zin.getNextEntry()) != null) {
    File newFile = new File(outdir, entry.getName());   // no isAllowExtract
    ...
    FileOutputStream fos = new FileOutputStream(newFile);
```

A zip entry named `../../whatever` therefore gets written outside `destDir`.

### Reachability

The Uri overload is called from `VMCreatorActivity` when importing a VM bundle (a caller-supplied content URI, reachable via the exported `RomReceiverActivity` for `*.cvbi` files). A crafted `.cvbi` opened from a browser/messenger can overwrite any app-writable file — other VMs' disk images, `roms-data.json`, shared storage files.

## Fix

Wrap the extraction-loop body in `if (isAllowExtract(entry, destDir)) { ... }`, exactly matching the String overload's existing guard. No behavior change for well-formed archives.

## Impact

Closes a path-traversal (Zip Slip) write primitive reachable through VM bundle import.