### PR TITLE
Block shell expansion and redirection in command safety check

### DIFF
--- a/app/src/main/java/com/vectras/vm/VMManager.java
+++ b/app/src/main/java/com/vectras/vm/VMManager.java
@@ -854,6 +854,22 @@ public class VMManager {
     public static boolean isthiscommandsafe(@NonNull String _command, Context _context) {
         Log.d("VMManager.isthiscommandsafe", _command);
 
+        // The command is written to a bash shell's stdin, so characters that
+        // trigger shell expansion, redirection, or process substitution let a
+        // crafted VM config execute arbitrary code even though the blacklist
+        // below only rejects & \n ; |.
+        String shellMetaCharacters = "$`><";
+        if (_command.contains(shellMetaCharacters.substring(0, 1))
+                || _command.contains(shellMetaCharacters.substring(1, 2))) {
+            latestUnsafeCommandReason = _context.getString(R.string.command_are_not_allowed_to_contain_shell_expansion);
+            return false;
+        }
+        if (_command.contains(shellMetaCharacters.substring(2, 3))
+                || _command.contains(shellMetaCharacters.substring(3, 4))) {
+            latestUnsafeCommandReason = _context.getString(R.string.command_are_not_allowed_to_contain_redirection);
+            return false;
+        }
+
         if (_command.startsWith("qemu")) {
             if (!_command.contains("&")) {
                 if (!_command.contains("\n")) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,8 @@
     <string name="command_are_not_allowed_to_contain_multiple_lines">Commands are not allowed to contain multiple lines.</string>
     <string name="command_are_not_allowed_to_contain_semicolons">Commands are not allowed to contain \";\".</string>
     <string name="command_are_not_allowed_to_contain_vertical_bars">Commands are not allowed to contain \"|\".</string>
+    <string name="command_are_not_allowed_to_contain_shell_expansion">Commands are not allowed to contain \"$\" or \"`\".</string>
+    <string name="command_are_not_allowed_to_contain_redirection">Commands are not allowed to contain \"&gt;\" or \"&lt;\".</string>
     <string name="reason">Reason</string>
     <string name="size_too_large_try_qcow2_format">Size too large, try qcow2 format.</string>
     <string name="disclaimer_when_using_rom">By using any files of this ROM or any files containing anything in any way, you agree that we (developers or contributors to Vectras VM) and the creator or creators of this ROM or these files will not be responsible for any unintended problems that will happen to you and your things. But if the creator or creators of this ROM or these files are confirmed to intentionally want to cause harm to you or anyone else, the creator or creators of this ROM or these files will be responsible. And it also means that you have agreed to the Terms and Policies of the owner, provider or owners, providers of the operating system or operating systems contained in this ROM.</string>


### PR DESCRIPTION
## Problem

`VMManager.isthiscommandsafe()` is the only gate between user-editable/imported QEMU command strings and a **bash shell** (the command is written to bash's stdin via `Terminal2`). It currently only rejects `&`, newline, `;`, and `|` — a trivially bypassable blacklist:

- **`\$(...)` / backticks** — command substitution executes at shell *expansion* time. `qemu-system-x86_64 \$(arbitrary command) ...` passes the check and runs the substitution.
- **`>` / `<`** — redirection can overwrite or read arbitrary app-writable files (other VMs' disks, `roms-data.json`, etc.).

These strings flow in from:

- VM extra params (user-editable in the creator, imported via `roms-data.json` / the store),
- restored `snapshot.sh` files (`StartVM.env()` re-validates and reuses saved commands),
- the exported `CqcmActivity` `command` intent extra (any installed app can supply it; see also #147 which un-exports that surface).

So a malicious VM config — or another app — could achieve arbitrary code execution inside the app's proot environment with all its permissions.

## Fix

Reject `\$` and backtick (shell expansion) and `>` and `<` (redirection) up front, with two new user-visible reason strings explaining what was blocked.

## Compatibility

I verified all internally generated commands (StartVM parameter assembly, `qemu-img create`, migrate/QMP commands, `snapshot.sh` restore content) contain none of the four characters, so legitimate flows are unaffected. Users with hand-crafted extra params that contained these characters will see the existing "harmful command" dialog with a specific reason.