### PR TITLE
Add timeout to migration status polling loops

### DIFF
--- a/app/src/main/java/com/vectras/vm/VMManager.java
+++ b/app/src/main/java/com/vectras/vm/VMManager.java
@@ -1045,7 +1045,16 @@ public class VMManager {
 
                         Boolean[] result = getMigrateStatus();
 
+                        // Treat an unreachable/errored QMP response as failure
+                        // after a grace period so this loop can never spin
+                        // forever and leave the VM paused with a stuck dialog.
+                        long migratePollingDeadline = System.currentTimeMillis() + 120_000;
+
                         while (!result[0] && !result[1]) {
+                            if (System.currentTimeMillis() > migratePollingDeadline) {
+                                result[1] = true;
+                                break;
+                            }
                             try {
                                 sleep(1000);
                             } catch (Exception ignored) {

--- a/app/src/main/java/com/vectras/vm/main/core/MainStartVM.java
+++ b/app/src/main/java/com/vectras/vm/main/core/MainStartVM.java
@@ -420,7 +420,17 @@ public class MainStartVM {
 
                                 Boolean[] result = VMManager.getMigrateStatus();
 
+                                // Treat an unreachable/errored QMP response as
+                                // failure after a grace period so this loop can
+                                // never spin forever and leave the boot dialog
+                                // stuck on "Resuming".
+                                long migratePollingDeadline = System.currentTimeMillis() + 120_000;
+
                                 while (!result[0] && !result[1]) {
+                                    if (System.currentTimeMillis() > migratePollingDeadline) {
+                                        result[1] = true;
+                                        break;
+                                    }
                                     try {
                                         Thread.sleep(1000);
                                     } catch (Exception ignored) {


### PR DESCRIPTION
## Problem

`getMigrateStatus()` returns `{false, false}` whenever QMP is unreachable or returns an error (QEMU died mid-migration, the QMP socket was removed, the snapshot file hit ENOSPC, ...). Both migration-status polling loops treated that as 'keep waiting' with **no exit condition**:

1. `VMManager.showPauseDialog()` (pause VM flow) — the progress dialog never resets, the VM stays paused, and `QmpSender.resume()` never runs.
2. `MainStartVM` boot watcher (resume flow) — the boot dialog is stuck on "Resuming" forever.

Concretely: a user pauses a VM while the disk is full → the migration fails silently → the app's dialog spins forever.

## Fix

Cap each loop at **120 seconds**. On timeout, treat the status as failed (`result[1] = true`) so the already-existing failure branches take over:

- pause flow: `QmpSender.resume()` + "VM state save failed" dialog + progress dialog reset
- resume flow: `QmpSender.quickShutdown()` + the existing keep/remove/close recovery dialog

120s is a generous ceiling — a healthy local migration to `exec:cat > snapshot.bin` completes in seconds even for multi-GB VMs, while genuinely dead QMP exits the wait within two minutes instead of never.