### PR TITLE
Clamp device selector indices to prevent crash on VM start

### DIFF
--- a/app/src/main/java/com/vectras/vm/creator/utils/VMCreatorSelector.java
+++ b/app/src/main/java/com/vectras/vm/creator/utils/VMCreatorSelector.java
@@ -59,7 +59,8 @@ public class VMCreatorSelector {
     }
 
     public static HashMap<String, Object> getGraphicsCard(Context context, int position) {
-        return ListManager.graphicCards(context).get(position);
+        ArrayList<HashMap<String, Object>> list = ListManager.graphicCards(context);
+        return list.get(position < 0 ? 0 : Math.min(position, list.size() - 1));
     }
 
     public static void networkCard(Activity activity, int position, UniversalPickerDialog.UniversalPickerDialogCallback callback) {
@@ -67,7 +68,8 @@ public class VMCreatorSelector {
     }
 
     public static HashMap<String, Object> getNetworkCard(Context context, int position) {
-        return ListManager.networkCards(context).get(position);
+        ArrayList<HashMap<String, Object>> list = ListManager.networkCards(context);
+        return list.get(position < 0 ? 0 : Math.min(position, list.size() - 1));
     }
 
     public static void usbController(Activity activity, int position, UniversalPickerDialog.UniversalPickerDialogCallback callback) {
@@ -75,7 +77,8 @@ public class VMCreatorSelector {
     }
 
     public static HashMap<String, Object> getUsbController(Context context, int position) {
-        return ListManager.usbControllers(context).get(position);
+        ArrayList<HashMap<String, Object>> list = ListManager.usbControllers(context);
+        return list.get(position < 0 ? 0 : Math.min(position, list.size() - 1));
     }
 
     public static void mouse(Activity activity, String arch, int position, UniversalPickerDialog.UniversalPickerDialogCallback callback) {
@@ -83,7 +86,8 @@ public class VMCreatorSelector {
     }
 
     public static HashMap<String, Object> getMouse(Context context, String arch, int position) {
-        return ListManager.mouseTypes(context, arch).get(position);
+        ArrayList<HashMap<String, Object>> list = ListManager.mouseTypes(context, arch);
+        return list.get(position < 0 ? 0 : Math.min(position, list.size() - 1));
     }
 
     public static void keyboard(Activity activity, String arch, int position, UniversalPickerDialog.UniversalPickerDialogCallback callback) {
@@ -91,7 +95,8 @@ public class VMCreatorSelector {
     }
 
     public static HashMap<String, Object> getKeyboard(Context context, String arch, int position) {
-        return ListManager.keyboardTypes(context, arch).get(position);
+        ArrayList<HashMap<String, Object>> list = ListManager.keyboardTypes(context, arch);
+        return list.get(position < 0 ? 0 : Math.min(position, list.size() - 1));
     }
 
     public static void soundCard(Activity activity, int position, UniversalPickerDialog.UniversalPickerDialogCallback callback) {
@@ -99,11 +104,13 @@ public class VMCreatorSelector {
     }
 
     public static HashMap<String, Object> getSoundCard(Context context, int position) {
-        return ListManager.soundCards(context).get(position);
+        ArrayList<HashMap<String, Object>> list = ListManager.soundCards(context);
+        return list.get(position < 0 ? 0 : Math.min(position, list.size() - 1));
     }
 
     public static HashMap<String, Object> getBootFrom(Context context, int position) {
-        return ListManager.bootFrom(context).get(position);
+        ArrayList<HashMap<String, Object>> list = ListManager.bootFrom(context);
+        return list.get(position < 0 ? 0 : Math.min(position, list.size() - 1));
     }
 
     public static void bootFrom(Activity activity, int position, UniversalPickerDialog.UniversalPickerDialogCallback callback) {
@@ -115,7 +122,8 @@ public class VMCreatorSelector {
     }
 
     public static HashMap<String, Object> getAccel(Context context, int position) {
-        return ListManager.accelTypes(context).get(position);
+        ArrayList<HashMap<String, Object>> list = ListManager.accelTypes(context);
+        return list.get(position < 0 ? 0 : Math.min(position, list.size() - 1));
     }
 
     public static void showDialog(Activity activity, ArrayList<HashMap<String, Object>> list, int position, UniversalPickerDialog.UniversalPickerDialogCallback callback, String title) {


### PR DESCRIPTION
## Problem

Eight getters in `VMCreatorSelector` — `getGraphicsCard`, `getNetworkCard`, `getUsbController`, `getMouse`, `getKeyboard`, `getSoundCard`, `getBootFrom`, `getAccel` — index their device lists directly with the position stored in the VM config:

```java
public static HashMap<String, Object> getGraphicsCard(Context context, int position) {
    return ListManager.graphicCards(context).get(position);   // no clamping
}
```

Meanwhile `getCpu`, `getCpuCore`, and `getMachine` already clamp (`position < 0 ? 0 : Math.min(position, list.size() - 1)`) — the eight above just never got the same treatment.

`StartVM.env()` calls all of them with indices straight from `rom-data.json`. An **imported ROM, a VM created by an older app version with shorter device lists, or a hand-edited config** with an out-of-range value crashes the VM start thread with an uncaught `ArrayIndexOutOfBoundsException` before QEMU even launches — the user just sees the generic start failure.

## Fix

Apply the exact same clamp expression already used by `getCpu()` to all eight getters. Out-of-range positions fall back to the first/last valid entry instead of crashing, which matches how the CPU picker already behaves.

## Impact

Eliminates a crash class on VM start driven by data compatibility (old configs / imports / edits).