### PR TITLE
Report failure status and destroy the process on Terminal2 errors

### DIFF
--- a/app/src/main/java/com/vectras/vterm/Terminal2.java
+++ b/app/src/main/java/com/vectras/vterm/Terminal2.java
@@ -182,7 +182,9 @@ public class Terminal2 {
 
     private resultData startProcess(String command, Process process, Terminal2Callback callback) {
         resultData data = new resultData();
-        AtomicInteger exitCode = new AtomicInteger();
+        // Start as ERROR so a failure before waitFor() (stream setup,
+        // proot dying mid-read) is never mistaken for a clean exit 0.
+        AtomicInteger exitCode = new AtomicInteger(ERROR);
 
         int MAX_LOG_SIZE = 200_000; // ~200KB text
         StringBuilder output = new StringBuilder();
@@ -217,12 +219,16 @@ public class Terminal2 {
             } catch (InterruptedException e) {
                 exitCode.set(ERROR);
             }
-            data.status = exitCode.get();
 
             reader.close();
         } catch (Exception e) {
             output.append(e.getMessage());
+            exitCode.set(ERROR);
             Log.e(TAG, "streamLog: ", e);
+        } finally {
+            if (process.isAlive()) {
+                process.destroy();
+            }
         }
 
         data.status = exitCode.get();


### PR DESCRIPTION
## Problem

In `Terminal2.startProcess()`:

```java
AtomicInteger exitCode = new AtomicInteger();      // starts at 0 == SUCCESS
...
} catch (Exception e) {
    output.append(e.getMessage());
    Log.e(TAG, "streamLog: ", e);
}
data.status = exitCode.get();                      // 0 == SUCCESS if waitFor never ran
```

If an exception occurs **before** `process.waitFor()` — stream setup fails, or the proot process dies mid-read so `readLine()` throws — `exitCode` stays 0 and the caller (`MainService.onFinished`) treats the failed run as a **clean exit**, silently skipping error handling (no "VM stopped" dialog, no try-again flow).

Additionally, on that path the proot `Process` was never `destroy()`ed — a leaked live process + its FDs on every occurrence.

## Fix

- Initialize `exitCode` to `ERROR` and also set it in the catch block, so any failure before the wait completes reports as a failure.
- Add a `finally` block that destroys the process if it is still alive.

No behavior change on the happy path: the real exit code from `waitFor()` still overwrites the initial value.