### PR TITLE
Fix store fragments crashing and reload-looping on null JSON

### DIFF
--- a/app/src/main/java/com/vectras/vm/main/romstore/RomStoreFragment.java
+++ b/app/src/main/java/com/vectras/vm/main/romstore/RomStoreFragment.java
@@ -107,7 +107,7 @@ public class RomStoreFragment extends Fragment {
     }
 
     private void loadData() {
-        List<DataRoms> dataRoms = new ArrayList<>();
+        List<DataRoms> dataRoms;
 
         try {
             Gson gson = new Gson();
@@ -116,7 +116,13 @@ public class RomStoreFragment extends Fragment {
         } catch (Exception e) {
             binding.linearload.setVisibility(View.GONE);
             binding.linearnothinghere.setVisibility(View.VISIBLE);
+            dataRoms = new ArrayList<>();
         }
+
+        // Gson returns null (it does not throw) for a "null"/blank body.
+        // Pushing null into the LiveData makes the observer call
+        // loadFromServer() again, looping network requests forever.
+        if (dataRoms == null) dataRoms = new ArrayList<>();
 
         homeRomStoreViewModel.setRomsList(dataRoms);
         data.clear();

--- a/app/src/main/java/com/vectras/vm/main/softwarestore/SoftwareStoreFragment.java
+++ b/app/src/main/java/com/vectras/vm/main/softwarestore/SoftwareStoreFragment.java
@@ -108,7 +108,7 @@ public class SoftwareStoreFragment extends Fragment {
     }
 
     private void loadData() {
-        List<DataRoms> dataSoftware = new ArrayList<>();
+        List<DataRoms> dataSoftware;
 
         try {
             Gson gson = new Gson();
@@ -117,7 +117,13 @@ public class SoftwareStoreFragment extends Fragment {
         } catch (Exception e) {
             binding.linearload.setVisibility(View.GONE);
             binding.linearnothinghere.setVisibility(View.VISIBLE);
+            dataSoftware = new ArrayList<>();
         }
+
+        // Gson returns null (it does not throw) for a "null"/blank body.
+        // Pushing null into the LiveData makes the observer call
+        // loadFromServer() again, looping network requests forever.
+        if (dataSoftware == null) dataSoftware = new ArrayList<>();
 
         homeSoftwareStoreViewModel.setSoftwareList(dataSoftware);
         data.clear();


### PR DESCRIPTION
## Problem

Both store fragments (ROM store and Software store) parse the server response like this:

```java
dataRoms = gson.fromJson(contentJSON, listType);   // returns null for "null"/blank bodies
} catch (Exception e) { ... }                      // dataRoms stays as declared
homeRomStoreViewModel.setRomsList(dataRoms);       // null propagated
data.addAll(dataRoms);                             // NPE if null
```

`Gson.fromJson` **returns null instead of throwing** when the body is a literal `null` or empty — which passes the preceding `!body.isEmpty()` check. Two consequences:

1. `data.addAll(null)` throws an NPE (crash).
2. Worse: the observer treats a null/empty list as 'reload':

```java
homeRomStoreViewModel.getRomsList().observe(..., roms -> {
    if (roms == null || roms.isEmpty()) {
        loadFromServer();        // -> loadData() -> setRomsList(null) -> observer -> ...
```

…so a bad store response turns into an **endless network request loop** hammering the store endpoint until the fragment is destroyed.

## Fix

In both `RomStoreFragment.loadData()` and `SoftwareStoreFragment.loadData()`:
- Default the parse result to an empty list when Gson returns null.
- Initialize the list inside the catch branch so a parse exception can't leave it null either.

The observer's reload branch now only fires for genuinely empty stores, and the 'nothing here' UI shows instead of a crash/loop.