### PR TITLE
Stop disabling TLS verification for setup downloads

### DIFF
--- a/app/src/main/java/com/vectras/vm/setupwizard/SetupWizard2Activity.java
+++ b/app/src/main/java/com/vectras/vm/setupwizard/SetupWizard2Activity.java
@@ -414,7 +414,7 @@ public class SetupWizard2Activity extends AppCompatActivity {
                         } else {
                             bootstrapFileLink = Objects.requireNonNull(mmap.get(DeviceUtils.is64bit() ? "amd64" : "x86")).toString();
                         }
-                        downloadBootstrapsCommand = " aria2c -x 4 --async-dns=false --disable-ipv6 --check-certificate=false -o setup.tar.gz " + bootstrapFileLink;
+                        downloadBootstrapsCommand = " aria2c -x 4 --async-dns=false --disable-ipv6 -o setup.tar.gz " + bootstrapFileLink;
                     }
                 }
                 new Handler(Looper.getMainLooper()).postDelayed(() -> {

--- a/app/src/main/java/com/vectras/vm/setupwizard/TurnipZinkSetupWizardActivity.java
+++ b/app/src/main/java/com/vectras/vm/setupwizard/TurnipZinkSetupWizardActivity.java
@@ -146,8 +146,8 @@ public class TurnipZinkSetupWizardActivity extends AppCompatActivity {
                 " echo \"Installing packages...\";" +
                 " apk add aria2 mesa-dri-gallium mesa-vulkan-swrast vulkan-loader mesa-utils vulkan-tools mesa-egl mesa-gbm mesa-vulkan-ati mesa-vulkan-broadcom mesa-vulkan-freedreno mesa-vulkan-panfrost;" +
                 " echo \"Downloading...\";" +
-                " aria2c -x 4 --async-dns=false --disable-ipv6 --check-certificate=false -o setup0.tar.gz " + libglvndFileUrl + ";" +
-                " aria2c -x 4 --async-dns=false --disable-ipv6 --check-certificate=false -o setup1.tar.gz " + mesaFileUrl + ";" +
+                " aria2c -x 4 --async-dns=false --disable-ipv6 -o setup0.tar.gz " + libglvndFileUrl + ";" +
+                " aria2c -x 4 --async-dns=false --disable-ipv6 -o setup1.tar.gz " + mesaFileUrl + ";" +
                 " echo \"Installing...\";" +
                 " tar -xzvf setup0.tar.gz -C /;" +
                 " tar -xzvf setup1.tar.gz -C /;" +


### PR DESCRIPTION
## Problem

Three `aria2c` invocations passed `--check-certificate=false`:

- `SetupWizard2Activity` — the **bootstrap archive** (`setup.tar.gz`), which is then extracted into the app's execution environment and is the QEMU base system.
- `TurnipZinkSetupWizardActivity` — the **GPU driver archives** (`setup0.tar.gz`, `setup1.tar.gz`), which are installed with `tar -xzvf ... -C /`.

With certificate verification disabled, a network attacker (hostile Wi-Fi, ISP, DNS hijack) can substitute a malicious archive, and the app happily extracts and uses it → **arbitrary code execution with the app's privileges**.

All the download sources are HTTPS GitHub release URLs (see `web/data/setupfiles*.json`), so TLS verification is precisely the protection these downloads need — there is no broken-cert scenario that requires disabling it here.

## Fix

Remove `--check-certificate=false` from all three aria2c commands. aria2c verifies TLS by default; no other flags change.

## Note

This is also a prerequisite for tightening the app-wide `usesCleartextTraffic` posture later, since the same wizard pipelines feed from these downloads.