### PR TITLE
Escape the VNC secret when embedding it in QEMU params

### DIFF
--- a/app/src/main/java/com/vectras/vm/StartVM.java
+++ b/app/src/main/java/com/vectras/vm/StartVM.java
@@ -418,7 +418,15 @@ public class StartVM {
 
         if (MainSettingsManager.getVmUi(context).equals("VNC")) {
             if (!MainSettingsManager.getVncExternalPassword(context).isEmpty()) {
-                params += "-object secret,id=vncpass,data=\"" + MainSettingsManager.getVncExternalPassword(context) + "\"";
+                // The command runs through a shell and QEMU parses data= with
+                // its own option parser, so both " (shell/quoting) and ,
+                // (option separator) and \ (escape) in the password must be
+                // escaped to keep them from breaking out of the secret value.
+                String escapedPassword = MainSettingsManager.getVncExternalPassword(context)
+                        .replace("\\", "\\\\")
+                        .replace("\"", "\\\"")
+                        .replace(",", "\\,");
+                params += "-object secret,id=vncpass,data=\"" + escapedPassword + "\"";
             }
 
             params += (params.isEmpty() ? "" : " ") + "-vnc ";


### PR DESCRIPTION
## Problem

`StartVM.getDisplayParams()` spliced the external VNC password raw into the QEMU command line:

```java
params += "-object secret,id=vncpass,data=\"" + password + "\"";
```

Two failure modes for a user-chosen password:

- A password containing `"` **breaks out of the surrounding quotes** — everything after it becomes extra shell tokens on the QEMU command line. Beyond the breakage, it's an injection point where attacker-influenced text (the password field flows from settings UI) becomes executable command context.
- A password containing `,` prematurely **terminates the `data=` value** in QEMU's option parser, silently truncating the secret (VNC auth then fails mysteriously).

## Fix

Escape backslash, double quote, and comma before embedding:

```java
.replace("\\", "\\\\").replace("\"", "\\\\\"").replace(",", "\\,")
```

Any printable password now round-trips intact through both the shell and QEMU's option parser.

`removeDisplayParams()` strips the whole `-object secret,id=vncpass...` option by id during snapshot restore, so that flow is unaffected.