### PR TITLE
Guard exported RunCommandService with a signature permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,14 @@
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
 
+    <!-- Signature-level guard for the exported RunCommandService: only apps
+         signed with this key may push commands into the app's shell. -->
+    <permission
+        android:name="com.termux.permission.RUN_COMMAND"
+        android:protectionLevel="signature" />
+
+    <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
+
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
@@ -237,6 +245,7 @@
         <service
             android:name="com.termux.app.RunCommandService"
             android:exported="true"
+            android:permission="com.termux.permission.RUN_COMMAND"
             android:stopWithTask="true" /> <!-- Termux-X11 -->
         <activity
             android:name=".x11.X11Activity"


### PR DESCRIPTION
## Problem

`com.termux.app.RunCommandService` takes `RUN_COMMAND_PATH` / `RUN_COMMAND_ARGUMENTS` from the starting intent and forwards them **directly into `TermuxService` execution** — but the manifest exported it with **no permission requirement**, and `com.termux.permission.RUN_COMMAND` was never declared anywhere in this app.

```xml
<service
    android:name="com.termux.app.RunCommandService"
    android:exported="true"
    android:stopWithTask="true" />
```

Consequence: **any installed app** can start this service with an intent pointing at an executable inside this app's data directory and have it run in the background — in a process holding `WRITE_SECURE_SETTINGS`, `MANAGE_EXTERNAL_STORAGE`, and a proot/QEMU environment. That's one-intent command execution.

Upstream Termux gates exactly this service with the signature-level `com.termux.permission.RUN_COMMAND`; the port simply dropped both the `<permission>` declaration and the `android:permission` attribute. (The class's own Javadoc still documents the permission requirement.)

## Fix

- Declare `com.termux.permission.RUN_COMMAND` with `protectionLevel="signature"`.
- Hold it via `<uses-permission>` and require it on the service with `android:permission`.

## Compatibility

- Nothing inside the app calls this service (verified by grep), so no internal flow changes.
- Third-party automation apps can no longer invoke it unless signed with the same key — which is the intended Termux semantics, and almost certainly nobody was legitimately depending on it in this app.

Closes the most severe finding of a security audit pass.