### PR TITLE
Stop exporting CqcmActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -167,7 +167,7 @@
         <activity
             android:name=".CqcmActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|smallestScreenSize|screenLayout"
-            android:exported="true" />
+            android:exported="false" />
         <activity
             android:name=".creator.QemuParamsEditorActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|smallestScreenSize|screenLayout"


### PR DESCRIPTION
## Problem

`CqcmActivity` is declared `android:exported="true"` with no permission guard, and its `onResume()` runs any command supplied via the `command` intent extra through `PendingCommand.runNow()`:

```java
if (getIntent().hasExtra("command")) {
    runCommand(getIntent().getStringExtra("command"));
```

`PendingCommand.runNow()` does consult `VMManager.isthiscommandsafe()` — but that check accepts anything starting with `qemu` that lacks `& \n ; |`. So **any installed app** could silently:

- launch `qemu-system-*` with `-drive file=...` pointing at private files (reading host files through the guest),
- run `qemu-img` commands that write/overwrite app-private disk files,
- start arbitrary QEMU networking — all with zero user interaction and no visual cue beyond the app coming to the foreground.

## Analysis of who needs it exported

- `CqcmActivity` has **no intent-filter** — it's only launchable by explicit component name.
- Nothing inside the app launches it via an external component reference, and no third-party integration is documented (its `exported="true"` dates back to the 2.9.2 initial import with no related feature ever using it).

## Fix

Set `android:exported="false"`. All in-app flows that start `CqcmActivity` (same process, explicit intent) continue to work unchanged.

Combined with #138 (shell meta-character blocking in the safety check), this closes the external command-execution surface entirely.