### PR TITLE
Harden backup and cleartext traffic posture

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,14 +39,15 @@
 
     <application
         android:name=".VectrasApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:banner="@mipmap/tv_banner"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:theme="@style/AppTheme">
         <activity
             android:name=".setupwizard.TurnipZinkSetupWizardActivity"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Block cleartext for remote traffic while keeping the local
+         host-shared-folder HTTP endpoints (QEMU user-net gateway)
+         working on all emulated interfaces. -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">10.0.2.15</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
## Problem

### 1. `allowBackup="true"` with no data-extraction rules

`adb backup`-class flows could pull the app's private data off the device: `roms-data.json` (all VM configs), settings prefs (including the **VNC password** saved by `MainSettingsManager`), and the entire termux/proot prefix under `files/`. For a VM app whose private storage *is* the user's virtual disks and configs, silently carrying that into cloud/ADB restores is both a privacy and integrity risk.

### 2. App-wide cleartext (`usesCleartextTraffic="true"`)

Every remote endpoint in the app is HTTPS (GitHub raw, anbui.ovh, Fedora virtio, release assets). The only legitimate cleartext traffic is the **host-shared-folder** HTTP server reached through QEMU user-net gateways (`http://10.0.2.2:19000`, `10.0.2.15`) and localhost. The global flag was unnecessary and silently allowed any MITM-able HTTP call anywhere (including from third-party code).

## Fix

- `allowBackup="false"`.
- Add `res/xml/network_security_config.xml`: cleartext permitted **only** for `10.0.2.2`, `10.0.2.15`, `127.0.0.1`, `localhost`; blocked for everything else via `base-config`.
- Reference it via `android:networkSecurityConfig` and flip `usesCleartextTraffic` to `false` (the security-config takes precedence per-domain).

## Compatibility

- Host-shared-folder flows keep working: they talk to `10.0.2.2`/localhost only.
- The remaining HTTP downgrade for two Alpine mirrors (`mirror.aarnet.edu.au`, `foobar.turbo.net.id` — user-selected entries that run **inside the guest's own alpine env**, not through Android's network stack) is unaffected by the Android-side policy; a follow-up could drop those two HTTP-only mirrors entirely.