### PR TITLE
Fix search adapters wiping their own data source on submitList

### DIFF
--- a/app/src/main/java/com/vectras/vm/main/romstore/RomStoreHomeAdpater.java
+++ b/app/src/main/java/com/vectras/vm/main/romstore/RomStoreHomeAdpater.java
@@ -130,8 +130,12 @@ public class RomStoreHomeAdpater extends RecyclerView.Adapter<RecyclerView.ViewH
     }
 
     public void submitList(List<DataRoms> newData) {
-        fullList.clear();
-        fullList = new ArrayList<>(newData);
+        // fullList usually aliases the caller's list (it is assigned in the
+        // constructor), so clear() would wipe the data this copy is meant to
+        // keep. Replace the reference instead of mutating the source list.
+        if (fullList != newData) {
+            fullList = new ArrayList<>(newData);
+        }
 
         displayList.clear();
 

--- a/app/src/main/java/com/vectras/vm/main/softwarestore/SoftwareStoreHomeAdapter.java
+++ b/app/src/main/java/com/vectras/vm/main/softwarestore/SoftwareStoreHomeAdapter.java
@@ -130,8 +130,12 @@ public class SoftwareStoreHomeAdapter extends RecyclerView.Adapter<RecyclerView.
     }
 
     public void submitList(List<DataRoms> newData) {
-        fullList.clear();
-        fullList = new ArrayList<>(newData);
+        // fullList usually aliases the caller's list (it is assigned in the
+        // constructor), so clear() would wipe the data this copy is meant to
+        // keep. Replace the reference instead of mutating the source list.
+        if (fullList != newData) {
+            fullList = new ArrayList<>(newData);
+        }
 
         displayList.clear();
 

--- a/app/src/main/java/com/vectras/vm/main/vms/VmsSearchAdapter.java
+++ b/app/src/main/java/com/vectras/vm/main/vms/VmsSearchAdapter.java
@@ -133,8 +133,12 @@ public class VmsSearchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     public void submitList(List<DataMainRoms> newData) {
-        fullList.clear();
-        fullList = new ArrayList<>(newData);
+        // fullList usually aliases the caller's list (it is assigned in the
+        // constructor), so clear() would wipe the data this copy is meant to
+        // keep. Replace the reference instead of mutating the source list.
+        if (fullList != newData) {
+            fullList = new ArrayList<>(newData);
+        }
 
         displayList.clear();
 


### PR DESCRIPTION
## Problem

All three search adapters (`VmsSearchAdapter`, `RomStoreHomeAdpater`, `SoftwareStoreHomeAdapter`) are constructed with **MainActivity's live search lists**:

```java
adapterVms = new VmsSearchAdapter(this, listVmsSearchData, true);          // fullList aliases the list
...
adapterRomStore = new RomStoreHomeAdpater(this, listSearchData, true);     // same for stores
adapterSoftwareStore = new SoftwareStoreHomeAdapter(this, listSearchData, true); // BOTH share listSearchData
```

and their `submitList()` then does:

```java
public void submitList(List<DataMainRoms> newData) {
    fullList.clear();                      // wipes the caller's list...
    fullList = new ArrayList<>(newData);   // ...then copies the now-empty list

    displayList.clear();
    loadMore();
}
```

Because `search()` fills `listVmsSearchData`/`listSearchData` and passes the same instance back into `submitList`, the `clear()` empties the data **before** it is copied — the copy is always empty.

### User-visible symptoms

- **The first search in a tab always shows the empty panel** even when matches exist; the second keystroke works because `search()` re-fills the list after the wipe.
- `listSearchData` is shared by both store adapters, so a ROM-store search corrupts the software-store adapter's source (and vice versa).

## Fix

Replace the `fullList` **reference** instead of mutating the source list; skip the copy when the same instance is passed back. `displayList` paging behavior is unchanged.