### PR TITLE
Return false from FileUtils.move when the copy fallback fails

### DIFF
--- a/app/src/main/java/com/vectras/vm/utils/FileUtils.java
+++ b/app/src/main/java/com/vectras/vm/utils/FileUtils.java
@@ -575,6 +575,7 @@ public class FileUtils {
                 return delete(new File(oldPath));
             } catch (Exception e) {
                 Log.e(TAG, "move: ", e);
+                return false;
             }
         }
         return true;


### PR DESCRIPTION
## Problem

`FileUtils.move()` falls back to copy+delete when `File.renameTo()` fails (e.g. across mount points). If that fallback **throws** — out of space, permission denied, I/O error — the exception is logged, swallowed, and execution falls through to `return true`:

```java
if (!src.renameTo(dst)) {
    try {
        copy(new File(oldPath), new File(newPath));
        return delete(new File(oldPath));
    } catch (Exception e) {
        Log.e(TAG, "move: ", e);
        // falls through
    }
}
return true;   // reached after a FAILED copy
```

Every caller trusts this boolean:

- `FileUtils.rename` → VM hide/unhide (`VmFileManager.hide/visible`)
- `VmFileManager.mark/unMark` → pending-delete/add marker files
- `moveToFolder` → recycle-bin move in `VMManager`
- `VMManager.backupMigrateFile/restoreMigrateFile` → snapshot `snapshot.bin` ↔ `snapshot.bin.bak`
- `ToolsManager` → virtio `virtio-win.bin` → `virtio-win.iso` rename

So failed moves were reported as success, leaving source and destination inconsistent (e.g. recycle-bin restore silently leaves the VM where it was, snapshot restore copies nothing yet reports OK).

## Fix

`return false;` inside the catch block. Happy-path behavior is unchanged.