### PR TITLE
Run the VM-list repair scan off the UI thread

### DIFF
--- a/app/src/main/java/com/vectras/vm/main/vms/VmsFragment.java
+++ b/app/src/main/java/com/vectras/vm/main/vms/VmsFragment.java
@@ -84,8 +84,14 @@ public class VmsFragment extends Fragment {
         binding.bnRomstore.setOnClickListener(v -> sharedViewModel.openRomStore.setValue(new Event<>(true)));
 
         binding.bnRepair.setOnClickListener(V -> {
-            VMManager.startFixRomsDataJson();
-            VMManager.fixRomsDataJsonResult(requireActivity());
+            // The repair walk scans every VM folder and rewrites
+            // roms-data.json; do it off the UI thread and report back when done.
+            executor.execute(() -> {
+                VMManager.startFixRomsDataJson();
+                if (!isAdded()) return;
+                requireActivity().runOnUiThread(() ->
+                        VMManager.fixRomsDataJsonResult(requireActivity()));
+            });
         });
 
         binding.wrlRomlist.setOnRefreshListener(() -> {


### PR DESCRIPTION
## Problem

The "Repair" button in the VM list ran the whole repair synchronously on the main thread:

```java
binding.bnRepair.setOnClickListener(V -> {
    VMManager.startFixRomsDataJson();               // walks EVERY folder under roms/,
    VMManager.fixRomsDataJsonResult(requireActivity()); // reads rom-data.json from each, rewrites roms-data.json
});
```

`startFixRomsDataJson()` does a full directory walk of the VM storage root plus a file read per VM, and the result dialog + `requestRefreshVmList` fire inline. With several VMs (or slow storage) the tap freezes the UI for the whole scan and can ANR.

## Fix

Reuse the fragment's existing single-thread executor for the scan and post `fixRomsDataJsonResult()` back to the UI thread when it finishes, with an `isAdded()` guard so a fragment torn down mid-scan can't touch views.