### PR TITLE
Fix i386 search filter never matching (case-sensitive tag compare)

### DIFF
--- a/app/src/main/java/com/vectras/vm/main/MainActivity.java
+++ b/app/src/main/java/com/vectras/vm/main/MainActivity.java
@@ -926,8 +926,11 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private boolean filterSearch(String arch, String os, boolean gui, boolean isContainsAds) {
-        return (searchArchTags.isEmpty() || searchArchTags.contains(arch)) &&
-                (searchOsTags.isEmpty() || searchOsTags.contains(os)) &&
+        // Store data and chips mix casing ("i386" vs "I386", "aarch64" vs
+        // "ARM64"), so compare tags case-insensitively instead of with a
+        // case-sensitive contains() that silently drops matches.
+        return (searchArchTags.isEmpty() || searchArchTags.toLowerCase().contains(String.valueOf(arch).toLowerCase())) &&
+                (searchOsTags.isEmpty() || searchOsTags.toLowerCase().contains(String.valueOf(os).toLowerCase())) &&
                 (searchIsContainsAds == null || searchIsContainsAds == isContainsAds) &&
                 (searchIsGui == null || searchIsGui == gui);
     }


### PR DESCRIPTION
## Problem

The ROM-store search builds its architecture chips with uppercase tags:

```java
private final String SEARCH_ARCH_I386_TAG = "I386";
...
searchArchTags.contains(arch)   // case-sensitive
```

But the store data uses lowercase `"i386"` (and `RomInfo` switches on `case "i386"`, `VMManager.setArch` handles `"i386"`). `"I386,".contains("i386")` is false, so **selecting the i386 chip filtered out every i386 ROM** — the chip always showed zero results.

`X86_64`, `ARM64`, and `PPC` happened to match the data's casing, which is why only i386 was visibly broken. The OS tags (`linux`/`windows`/…) work today but rely on the same fragile case-sensitive `contains`.

## Fix

Compare both tag groups case-insensitively in `filterSearch()` (`toLowerCase()` on both sides). Chip behavior for the already-matching tags is unchanged.