### PR TITLE
Fix valid .cvbi.zip imports rejected in the URI import path

### DIFF
--- a/app/src/main/java/com/vectras/vm/creator/VMCreatorActivity.java
+++ b/app/src/main/java/com/vectras/vm/creator/VMCreatorActivity.java
@@ -877,7 +877,12 @@ public class VMCreatorActivity extends AppCompatActivity {
     private void importRom(Uri fileUri, String filePath, String fileName) {
         if (isFinishing() || isDestroyed()) return;
 
-        if (!(fileName.endsWith(".cvbi") || filePath.endsWith(".cvbi.zip"))) {
+        // fileName is always present (it comes from the picker/URI), while
+        // filePath can legitimately be empty when the file lives on a
+        // content provider - exactly the case the URI import path exists
+        // for. So the extension must be checked against fileName, which
+        // also covers the .cvbi.zip bundle form.
+        if (!(fileName.endsWith(".cvbi") || fileName.endsWith(".cvbi.zip"))) {
             DialogUtils.oneDialog(this,
                     getResources().getString(R.string.problem_has_been_detected),
                     getResources().getString(R.string.format_not_supported_please_select_file_with_format_cvbi),


### PR DESCRIPTION
## Problem

`VMCreatorActivity.importRom()` validated extensions like this:

```java
if (!(fileName.endsWith(".cvbi") || filePath.endsWith(".cvbi.zip"))) {
    // "format not supported" dialog
```

The `.cvbi.zip` clause tests **`filePath`** — but `filePath` is exactly the value the method itself treats as optional: when a SAF/content-provider URI can't be resolved to a real filesystem path it comes back empty or non-existent, and that's the whole reason the `isUseUri = true` branch exists a few lines below.

So a valid `MyDistro.cvbi.zip` opened from such a provider (Drive, some document providers) failed the extension check **before** the URI import path could run, showing "Format not supported, please select file with format .cvbi" for a bundle the code was explicitly built to accept.

## Fix

Check the extension against `fileName` — which is always populated (from the picker display name / URI) and which also covers the `.cvbi.zip` bundle form:

```java
if (!(fileName.endsWith(".cvbi") || fileName.endsWith(".cvbi.zip")))
```

Callers that pass a real path still pass through unchanged; only the previously-broken provider/URI case is fixed.