### PR TITLE
Fix software store search bar never disabled while loading

### DIFF
--- a/app/src/main/java/com/vectras/vm/main/softwarestore/SoftwareStoreFragment.java
+++ b/app/src/main/java/com/vectras/vm/main/softwarestore/SoftwareStoreFragment.java
@@ -91,7 +91,9 @@ public class SoftwareStoreFragment extends Fragment {
 
     private void loadFromServer() {
         SharedViewModel sharedViewModel = new ViewModelProvider(this).get(SharedViewModel.class);
-        sharedViewModel.onSoftwareStoreLoaded.setValue(new Event<>(true));
+        // false = loading: MainActivity disables the search bar while the
+        // store list is still downloading, mirroring the ROM store flow.
+        sharedViewModel.onSoftwareStoreLoaded.setValue(new Event<>(false));
 
         binding.linearload.setVisibility(View.VISIBLE);
 


### PR DESCRIPTION
## Problem

The two store fragments signal their load state to MainActivity through `SharedViewModel` events, which control whether the search bar is enabled (`bindingContent.searchbar.setEnabled(isLoaded)`).

The ROM store does it correctly:

```java
// RomStoreFragment.loadFromServer()
sharedViewModel.onRomStoreLoaded.setValue(new Event<>(false));   // loading
...
sharedViewModel.onRomStoreLoaded.setValue(new Event<>(true));    // done (loadData)
```

The software store posted `true` **both** at the start and at the end of `loadFromServer()` — a copy-paste inversion. Since the event is `true` from the very beginning, the search bar is never disabled while the store list is still downloading.

Searching immediately after switching to the Software Store tab therefore runs against the still-empty/stale list, showing an empty result view instead of waiting for the data.

## Fix

Post `new Event<>(false)` at load start, mirroring the ROM store flow; the completion path already posts `true`.