### PR TITLE
Fix recycled store items keeping the previous item's click listener and red text

### DIFF
--- a/app/src/main/java/com/vectras/vm/main/romstore/RomStoreHomeAdpater.java
+++ b/app/src/main/java/com/vectras/vm/main/romstore/RomStoreHomeAdpater.java
@@ -28,6 +28,7 @@ public class RomStoreHomeAdpater extends RecyclerView.Adapter<RecyclerView.ViewH
     private List<DataRoms> fullList;
     private final List<DataRoms> displayList;
     private final boolean isBrighterItemBackground;
+    private final int textAvailDefaultColor = Color.LTGRAY;
 
     public RomStoreHomeAdpater(Context context, List<DataRoms> data, boolean isBrighterItemBackground) {
         this.context = context;
@@ -81,7 +82,10 @@ public class RomStoreHomeAdpater extends RecyclerView.Adapter<RecyclerView.ViewH
             });
 
             myHolder.textAvail.setText(context.getString(R.string.available) + (current.containsAds ? " • " + context.getString(R.string.contains_ads) : ""));
+            // Reset the color a previous recycled bind may have set to red.
+            myHolder.textAvail.setTextColor(textAvailDefaultColor);
         } else {
+            myHolder.linearItem.setOnClickListener(null);
             myHolder.textAvail.setText(context.getString(R.string.unavailable) + (current.containsAds ? " • " + context.getString(R.string.contains_ads) : ""));
             myHolder.textAvail.setTextColor(Color.RED);
         }

--- a/app/src/main/java/com/vectras/vm/main/softwarestore/SoftwareStoreHomeAdapter.java
+++ b/app/src/main/java/com/vectras/vm/main/softwarestore/SoftwareStoreHomeAdapter.java
@@ -29,6 +29,7 @@ public class SoftwareStoreHomeAdapter extends RecyclerView.Adapter<RecyclerView.
     private List<DataRoms> fullList;
     private final List<DataRoms> displayList;
     private final boolean isBrighterItemBackground;
+    private final int textAvailDefaultColor = Color.LTGRAY;
 
     public SoftwareStoreHomeAdapter(Context context, List<DataRoms> data, boolean isBrighterItemBackground) {
         this.context = context;
@@ -81,7 +82,10 @@ public class SoftwareStoreHomeAdapter extends RecyclerView.Adapter<RecyclerView.
                 context.startActivity(intent);
             });
             myHolder.textAvail.setText(context.getString(R.string.available) + (current.containsAds ? " • " + context.getString(R.string.contains_ads) : ""));
+            // Reset the color a previous recycled bind may have set to red.
+            myHolder.textAvail.setTextColor(textAvailDefaultColor);
         } else {
+            myHolder.linearItem.setOnClickListener(null);
             myHolder.textAvail.setText(context.getString(R.string.unavailable) + (current.containsAds ? " • " + context.getString(R.string.contains_ads) : ""));
             myHolder.textAvail.setTextColor(Color.RED);
         }


### PR DESCRIPTION
## Problem

Both store adapters (`RomStoreHomeAdpater`, `SoftwareStoreHomeAdapter`) only assign the item click listener in the `romAvail` branch:

```java
if (current.romAvail) {
    myHolder.linearItem.setOnClickListener(v -> { ...open RomInfo for current... });
    myHolder.textAvail.setText(...available...);      // color never restored
} else {
    myHolder.textAvail.setText(...unavailable...);
    myHolder.textAvail.setTextColor(Color.RED);       // never reset
}
```

RecyclerView **recycles holders**, so after scrolling:

1. A holder previously bound to an *available* item still carries that item's listener when rebound to an *unavailable* item → **tapping an "Unavailable" entry opens the RomInfo page of a different ROM** that used to occupy that holder.
2. `setTextColor(Color.RED)` is never reverted → some "Available" labels render red.

## Fix

- `setOnClickListener(null)` in the unavailable branch.
- Restore the default availability-label color in the available branch (`textAvailDefaultColor`, matching the theme's light gray).,