### PR TITLE
Honor isCheckVeryLow on Android versions below O

### DIFF
--- a/app/src/main/java/com/vectras/vm/utils/DeviceUtils.java
+++ b/app/src/main/java/com/vectras/vm/utils/DeviceUtils.java
@@ -47,7 +47,7 @@ public class DeviceUtils {
                 long availableBytes = availableBlocks * blockSize;
                 long availableMB = availableBytes / (1024 * 1024);
 
-                return availableMB < 2048;
+                return availableMB < (isCheckVeryLow ? 256 : 2048);
             } catch (Exception e) {
                 Log.e(TAG, "Error getting storage stats", e);
             }


### PR DESCRIPTION
## Problem

`DeviceUtils.isStorageLow(context, isCheckVeryLow)` applies the caller's threshold only on API 26+:

```java
if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
    ...
    return availableMB < 2048;                      // isCheckVeryLow ignored!
} else {
    ...
    return availableMB < (isCheckVeryLow ? 256 : 2048);
}
```

The project's minSdk is 23, so the pre-O branch is live. `VmsFragment` calls it with `true` ("very low", 256 MB) for its create/restore storage checks — on Android 7.x devices those checks instead used the 2 GB threshold, **blocking VM creation and restore with "not enough storage" while ~1.9 GB was still free**.

## Fix

Use the same threshold expression in the pre-O branch:

```java
return availableMB < (isCheckVeryLow ? 256 : 2048);
```

No behavior change on API 26+.