### PR TITLE
Fix VNC display number crash on typing, saving, and resuming

### DIFF
--- a/app/src/main/java/com/vectras/vm/settings/ExternalVNCSettingsActivity.java
+++ b/app/src/main/java/com/vectras/vm/settings/ExternalVNCSettingsActivity.java
@@ -36,7 +36,15 @@ public class ExternalVNCSettingsActivity extends AppCompatActivity {
     public void onStop() {
         super.onStop();
         MainSettingsManager.setVncExternal(this, binding.swEnabled.isChecked());
-        MainSettingsManager.setVncExternalDisplay(this, Objects.requireNonNull(binding.etDisplay.getText()).toString());
+        // Persist the display number only when it parses; MainActivity
+        // parses this value on every resume, so saving raw text (e.g. a
+        // stray "-") would crash the app on the next launch.
+        try {
+            Integer.parseInt(binding.etDisplay.getText().toString());
+            MainSettingsManager.setVncExternalDisplay(this, binding.etDisplay.getText().toString());
+        } catch (NumberFormatException ignored) {
+
+        }
         MainSettingsManager.setVncExternalPassword(this, Objects.requireNonNull(binding.etPassword.getText()).toString());
     }
 
@@ -104,9 +112,20 @@ public class ExternalVNCSettingsActivity extends AppCompatActivity {
                 binding.cvCopyport.setVisibility(View.VISIBLE);
         }
 
-        int result = Integer.parseInt(display) + 5900;
+        // The field allows signed input (and pastes), so partial or huge
+        // values like "-", "1-", or a 12-digit number must not crash here.
+        int displayNumber;
+        try {
+            displayNumber = Integer.parseInt(display);
+        } catch (NumberFormatException e) {
+            binding.tilDisplay.setError(getString(R.string.you_need_to_set_a_number_for_the_display));
+            binding.cvCopyport.setVisibility(View.GONE);
+            return;
+        }
 
-        if (result > 65535) {
+        int result = displayNumber + 5900;
+
+        if (result > 65535 || result < 5900) {
             binding.tilDisplay.setError(getString(R.string.need_to_set_smaller_screen_number));
             if (binding.cvCopyport.getVisibility() == View.VISIBLE)
                 binding.cvCopyport.setVisibility(View.GONE);


### PR DESCRIPTION
## Problem

Three linked bugs around the external VNC display number in `ExternalVNCSettingsActivity`:

### 1. Typing "-" crashes the app

The display field is declared `android:inputType="numberSigned"` (allows a minus sign), and `VNCPort()` runs `Integer.parseInt(display)` inside a `TextWatcher` on **every keystroke**. Typing a partial value like `-` (or anything unparseable like `1-`) throws an uncaught `NumberFormatException` → immediate crash.

### 2. Invalid values persist → crash loop on next resume

`onStop()` saves the raw text unvalidated:

```java
MainSettingsManager.setVncExternalDisplay(this, binding.etDisplay.getText().toString());
```

and `MainActivity.onResume` does `Integer.parseInt(MainSettingsManager.getVncExternalDisplay(this))` on every resume — so one invalid save turns into a **crash loop on app reopen**, before any VM even starts.

### 3. Negative display numbers pass the port check

`if (result > 65535)` rejects too-large ports but happily accepts negative ones (e.g. display = `-5` → port 5895), which later connects to an unintended port.

## Fix

- Parse defensively; on `NumberFormatException` show the existing "set a number" error and skip.
- In `onStop()`, persist the display number **only** when it parses.
- Reject ports outside `5900–65535`.