### PR TITLE
Reuse one bitmap in the VNC framebuffer drawable (per-frame allocation fix)

### DIFF
--- a/app/src/main/java/android/androidVNC/FullBufferBitmapData.java
+++ b/app/src/main/java/android/androidVNC/FullBufferBitmapData.java
@@ -22,7 +22,10 @@ class FullBufferBitmapData extends AbstractBitmapData {
 
 	int xoffset;
 	int yoffset;
-	
+	// Single reusable bitmap backing the drawable. Created lazily on the
+	// first draw and reused for every subsequent frame.
+	private Bitmap bitmap;
+
 	/**
 	 * @author Michael A. MacDonald
 	 *
@@ -40,33 +43,35 @@ class FullBufferBitmapData extends AbstractBitmapData {
 		/* (non-Javadoc)
 		 * @see android.graphics.drawable.DrawableContainer#draw(android.graphics.Canvas)
 		 */
-		@Override
-		public void draw(Canvas canvas) {
+	@Override
+	public void draw(Canvas canvas) {
 			int[] pixels = bitmapPixels;
 			if (pixels == null) {
 				return;
 			}
 
+			// Reuse one bitmap across draws. Creating a full-frame bitmap
+			// here put an allocation plus a whole-frame pixel copy on the UI
+			// thread for every framebuffer update (many times per second),
+			// causing constant GC pressure and visible jank.
+			if (bitmap == null) {
+				bitmap = Bitmap.createBitmap(framebufferwidth, framebufferheight, Config.bitmapConfig);
+			}
+
 			if (vncCanvas.getScaleType() == ImageView.ScaleType.FIT_CENTER || vncCanvas.getScaleType() == ImageView.ScaleType.FIT_XY)
 			{
-				//canvas.drawBitmap(data.bitmapPixels, 0, data.framebufferwidth, xoffset, yoffset, framebufferwidth, framebufferheight, false, null);
-
-                //XXX; Vectras: for Hardware accelerated surfaces we have to stop using the above deprecated method and use a bitmap-backed method
-                // this fixes the issue with Nougat Devices displaying black screen for 24bit color mode C24bit
-                Bitmap bitmapTmp = Bitmap.createBitmap(framebufferwidth, framebufferheight, Config.bitmapConfig);
-                bitmapTmp.setPixels(pixels, 0, data.framebufferwidth, 0, 0, framebufferwidth, framebufferheight);
+				bitmap.setPixels(pixels, 0, data.framebufferwidth, 0, 0, framebufferwidth, framebufferheight);
 
 				if (vncCanvas.getScaleType() == ImageView.ScaleType.FIT_XY) {
-					canvas.drawBitmap(bitmapTmp, (float) vncCanvas.getWidth() / 2 + (float) framebufferwidth / -2, (float) vncCanvas.getHeight() / 2 - (float) framebufferheight / 2, null);
+					canvas.drawBitmap(bitmap, (float) vncCanvas.getWidth() / 2 + (float) framebufferwidth / -2, (float) vncCanvas.getHeight() / 2 - (float) framebufferheight / 2, null);
 				} else {
-					canvas.drawBitmap(bitmapTmp, xoffset, yoffset, null);
+					canvas.drawBitmap(bitmap, xoffset, yoffset, null);
 				}
 
 
 			}
 			else
 			{
-				float scale = vncCanvas.getScale();
 				int xo = xoffset < 0 ? 0 : xoffset;
 				int yo = yoffset < 0 ? 0 : yoffset;
 				/*
@@ -81,13 +86,8 @@ class FullBufferBitmapData extends AbstractBitmapData {
 						drawHeight = data.framebufferheight - yo;
 
 
-					//canvas.drawBitmap(data.bitmapPixels, offset(xo, yo), data.framebufferwidth, xo, yo, drawWidth, drawHeight, false, null);
-
-                    //XXX; for Hardware accelerated surfaces we have to stop using the above deprecated method and use a bitmap-backed method
-                    // this fixes the issue with Nougat Devices displaying black screen for 24bit color mode C24bit
-                    Bitmap bitmapTmp = Bitmap.createBitmap(framebufferwidth, framebufferheight, Config.bitmapConfig);
-                    bitmapTmp.setPixels(pixels, offset(xo, yo), data.framebufferwidth, 0, 0, drawWidth, drawHeight);
-                    canvas.drawBitmap(bitmapTmp, 0, 0, null);
+					bitmap.setPixels(pixels, offset(xo, yo), data.framebufferwidth, 0, 0, drawWidth, drawHeight);
+					canvas.drawBitmap(bitmap, 0, 0, null);
 
 				/*
 				}
@@ -99,7 +99,7 @@ class FullBufferBitmapData extends AbstractBitmapData {
 					int scaleheight = (int)(vncCanvas.getVisibleHeight() / scale + 1);
 					if (scaleheight + yo > data.framebufferheight)
 						scaleheight = data.framebufferheight - yo;
-					canvas.drawBitmap(data.bitmapPixels, offset(xo, yo), data.framebufferwidth, xo, yo, scalewidth, scaleheight, false, null);				
+					canvas.drawBitmap(data.bitmapPixels, offset(xo, yo), data.framebufferwidth, xo, yo, scalewidth, scaleheight, false, null);
 				}
 				*/
 			}
@@ -224,8 +224,11 @@ class FullBufferBitmapData extends AbstractBitmapData {
 	 */
 	@Override
 	void updateBitmap(int x, int y, int w, int h) {
-		// Don't need to do anything here
-
+		// Keep the reusable bitmap in sync so the next draw() does not
+		// have to copy the whole framebuffer again.
+		if (bitmap != null && bitmapPixels != null) {
+			bitmap.setPixels(bitmapPixels, offset(x, y), framebufferwidth, x, y, w, h);
+		}
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
## Problem

`FullBufferBitmapData.Drawable.draw()` allocated a **brand-new full-frame Bitmap on every single draw**:

```java
Bitmap bitmapTmp = Bitmap.createBitmap(framebufferwidth, framebufferheight, Config.bitmapConfig);
bitmapTmp.setPixels(pixels, ...);
canvas.drawBitmap(bitmapTmp, ...);
```

`reDraw()` fires per framebuffer rect update — and per hextile tile-row (`VncCanvas.java:1706`) — so during interactive use this ran many times per second on the UI thread. For a 1920×1080 guest that is an **~8 MB allocation plus a whole-frame pixel copy per redraw**, i.e. constant GC pressure and visible jank while using the VM.

Additionally `updateBitmap()` — the hook the decoders call per dirty rect — was a no-op, so nothing incremental ever happened; every draw just re-copied the entire framebuffer wholesale.

## Fix

- Keep **one lazily-created Bitmap** in `FullBufferBitmapData` and `setPixels` into it on each draw (both the FIT_CENTER/FIT_XY and pan branches).
- Implement `updateBitmap(x, y, w, h)` to copy just the dirty rect into the reusable bitmap, so the decoders' per-rect calls keep it in sync incrementally.

Drawing behavior is unchanged: same draw paths, same local-cursor rendering, same scaling. This is the single biggest rendering win in the VNC path — per-rect work drops from 'allocate ~8 MB + copy full frame' to 'copy one rect into an existing bitmap'.