### PR TITLE
Always reset isKillingService so VM starts cannot hang forever

### DIFF
--- a/app/src/main/java/com/vectras/vm/manager/VmServiceManager.java
+++ b/app/src/main/java/com/vectras/vm/manager/VmServiceManager.java
@@ -12,7 +12,24 @@ public class VmServiceManager {
     public static void stopService(Context context) {
         isKillingService = true;
         new Thread(() -> {
-            if (!ProcessManager.isQemuRunning(context)) {
+            try {
+                // A single check is not enough: another VM or a leftover
+                // qemu process can still be visible at this instant, and
+                // skipping the reset would leave isKillingService stuck
+                // true - MainStartVM.startNow() waits on this flag in a
+                // 3s-sleep loop, so every later VM start would hang until
+                // the app is killed. Poll until QEMU is gone, with a
+                // timeout as a safety net.
+                long deadline = System.currentTimeMillis() + 60_000;
+                while (ProcessManager.isQemuRunning(context)
+                        && System.currentTimeMillis() < deadline) {
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        break;
+                    }
+                }
+            } finally {
                 new Handler(Looper.getMainLooper()).post(() -> {
                     MainService.stopService();
                     isKillingService = false;


### PR DESCRIPTION
## Problem

`VmServiceManager.stopService()` checked `isQemuRunning()` **exactly once**:

```java
isKillingService = true;
new Thread(() -> {
    if (!ProcessManager.isQemuRunning(context)) {   // single check, no retry
        ...
        isKillingService = false;
    }
}).start();
```

If any `qemu-system-` process is still visible in `ps` at that instant — a second concurrently started VM (`MainStartVM` only guards the *same* vmID), or a leftover process from `pkill -9` — the reset branch never runs, there is no retry, and `isKillingService` stays **stuck `true` forever**.

Every subsequent `MainStartVM.startNow()` then spins in:

```java
while (!breakNow && VmServiceManager.isKillingService) { Thread.sleep(3000); }
```

So the "Start VM" dialog never proceeds — for **any** VM — until the app is killed. Cancelling only sets `breakNow`, which the next attempt resets, hitting the same wall again. This permanently breaks one of the app's core flows with no error message.

## Fix

- Poll `isQemuRunning()` in a loop (1 s interval) until QEMU is actually gone, with a **60 s timeout** as a safety net.
- Always stop the service and reset `isKillingService` in a `finally` block, so the flag can never stick regardless of process state or an interrupted sleep.