### PR TITLE
Repair flow no longer moves hidden VMs into the recycle bin

### DIFF
--- a/app/src/main/java/com/vectras/vm/VMManager.java
+++ b/app/src/main/java/com/vectras/vm/VMManager.java
@@ -615,6 +615,15 @@ public class VMManager {
         if (!_filelist.isEmpty()) {
             for (int _repeat = 0; _repeat < _filelist.size(); _repeat++) {
                 if (_startRepeat < _filelist.size()) {
+                    if (isVMHidden(_filelist.get(_startRepeat)))
+                        // A hidden VM ("_"-prefixed folder) is re-added to the
+                        // list by the rebuild below, so it must be un-hidden
+                        // again - exactly what restoreAll() does. Leaving it
+                        // hidden would make moveAllBrokenVMRecycleBin() treat
+                        // the healthy folder as broken (the list stores the
+                        // un-prefixed vmID) and move it to the recycle bin.
+                        unHideVM(_filelist.get(_startRepeat));
+
                     if (isFileExists(_filelist.get(_startRepeat) + "/vmID.txt")) {
                         if (isFileExists(_filelist.get(_startRepeat) + "/rom-data.json")) {
                             tempRomData = FileUtils.readAFile(_filelist.get(_startRepeat) + "/rom-data.json");


### PR DESCRIPTION
## Problem

`startFixRomsDataJson()` (the "Repair" button) re-adds **every** VM folder's `rom-data.json` to the rebuilt list — including **hidden** (`_`-prefixed) folders from "delete with keep files" — but never un-hides them, unlike `restoreAll()` which calls `unHideVM()` for exactly this case.

`fixRomsDataJsonResult()` then immediately calls `moveAllBrokenVMRecycleBin()`, which tests each folder with a raw substring check:

```java
if (!vmList.contains(f.getName())) {      // f.getName() == "_abc123"
    FileUtils.moveToFolder(f.getAbsolutePath(), AppConfig.recyclebin);
```

The rebuilt list stores the **un-prefixed** vmID and paths, so `"_abc123"` never appears in it — and the healthy VM that was just "repaired" into the list has its entire folder (disk image included) **moved to the recycle bin seconds later**. The next repair run then drops it from the list entirely since the folder is gone. The dialog still reports "fixed successfully".

User flow that hits this: hide a VM (or delete-with-keep-files) → later press Repair → VM reappears in the list but fails to start ("No such file or directory"), disk silently in the recycle bin.

## Fix

Un-hide the folder before adding its config to the rebuilt list, mirroring what `restoreAll()` already does. Hidden VMs survive the repair flow and stay hidden-to-visible consistently with the rest of the codebase.