### PR TITLE
Release the AudioTrack when the audio stream stops

### DIFF
--- a/app/src/main/java/com/vectras/vm/sound/StreamAudio.java
+++ b/app/src/main/java/com/vectras/vm/sound/StreamAudio.java
@@ -31,8 +31,23 @@ public class StreamAudio {
     }
 
     public void stop() {
-        if (audioTrack != null) audioTrack.stop();
         isPlay = false;
+        // A MODE_STREAM AudioTrack holds native buffers and an audio
+        // session; stop() alone does not free them. This class is a
+        // singleton restarted for every VM run and every mute toggle, and
+        // streamFromFile() builds a new AudioTrack each time, so without
+        // release() every cycle orphaned one native track until creation
+        // started failing and VM audio stopped working app-wide.
+        AudioTrack oldTrack = audioTrack;
+        audioTrack = null;
+        if (oldTrack != null) {
+            try {
+                oldTrack.stop();
+            } catch (IllegalStateException ignored) {
+
+            }
+            oldTrack.release();
+        }
     }
 
     public void play() {


### PR DESCRIPTION
## Problem

`StreamAudio.streamFromFile()` builds a **new `AudioTrack`** on every start, but `stop()` only called `AudioTrack.stop()` — the track was never `release()`d, and the field was simply overwritten the next time:

```java
public void stop() {
    if (audioTrack != null) audioTrack.stop();   // never release()
    isPlay = false;
}
...
audioTrack = new AudioTrack.Builder()...build();  // new instance every start
```

`streamAudio` is a **singleton** (see `VmAudioManager`) restarted for every VM run and every mute toggle (`VmControllerDialog.mute`), so each cycle **orphaned one native AudioTrack** — its native buffers plus an audio session id. After enough cycles, `AudioTrack.Builder().build()` starts failing on the device and **VM audio stops working app-wide until reboot**.

A secondary race: the old track's reader thread could still be blocked inside `audioTrack.write()` while the new track was constructed.

## Fix

In `stop()`: clear the field first, then `stop()` + `release()` the old track (guarding `stop()` with `IllegalStateException` catch for the already-released case).

Safety review of the change:
- The reader loop condition (`while (isPlay ...)`) exits before touching the released track because `isPlay` is set `false` first.
- `setVolume()` and `applyEffect()` already null-check `audioTrack`/`soundEffect`; no external code reads the `audioTrack` field directly.