### PR TITLE
Cut QMP round-trip latency and cache the QEMU capability probe

### DIFF
--- a/app/src/main/java/com/vectras/qemu/utils/QmpClient.java
+++ b/app/src/main/java/com/vectras/qemu/utils/QmpClient.java
@@ -47,19 +47,20 @@ public class QmpClient {
 
 
 			sendRequest(out, QmpClient.requestCommandMode);
-			while(true){
-                response = getResponse(in);
-                if(response == null || response.equals("") || trial < 10)
-				    break;
-
-                Thread.sleep(1000);
+			trial = 0;
+			while ((response = getResponse(in)).equals("") && trial < 5) {
+				// Short backoff instead of full seconds: these round-trips
+				// sit on the hot path for every mouse click, key press,
+				// and status poll, where a 10x1s retry froze the action
+				// for up to ten seconds.
+				Thread.sleep(50L * (trial + 1));
 				trial++;
 			}
 
 			sendRequest(out, command);
-			trial=0;
-			while((response = getResponse(in)).equals("") && trial < 10){
-				Thread.sleep(1000);
+			trial = 0;
+			while ((response = getResponse(in)).equals("") && trial < 10) {
+				Thread.sleep(50L * (trial + 1));
 				trial++;
 			}
 		} catch (java.net.ConnectException e) {

--- a/app/src/main/java/com/vectras/vm/manager/QemuManager.java
+++ b/app/src/main/java/com/vectras/vm/manager/QemuManager.java
@@ -10,8 +10,21 @@ public class QemuManager {
     public static final int DEFAULT_REFRESH_RATE = 60;
     public static final int DEFAULT_LOW_REFRESH_RATE = 30;
 
+    // Probing runs "qemu-system-* -vnc help" in a proot shell (1-3s) and
+    // the answer cannot change while the app runs, so cache it per arch.
+    private static final java.util.Map<String, Boolean> refreshRateSupportCache = new java.util.HashMap<>();
+
     public static boolean isSupportSetRefreshRate(Context context) {
-        return new Terminal2(context).executeOnThisThread(getQemuExecutableFile(context) + " -vnc help").contains("refresh-rate");
+        String arch = MainSettingsManager.getArch(context);
+        synchronized (refreshRateSupportCache) {
+            Boolean cached = refreshRateSupportCache.get(arch);
+            if (cached != null) return cached;
+        }
+        boolean supported = new Terminal2(context).executeOnThisThread(getQemuExecutableFile(context) + " -vnc help").contains("refresh-rate");
+        synchronized (refreshRateSupportCache) {
+            refreshRateSupportCache.put(arch, supported);
+        }
+        return supported;
     }
 
     public static boolean isSupportAcpiTable(Context context) {


### PR DESCRIPTION
## Problem — two hot-path performance issues

### 1. QMP retries slept full seconds per round

`QmpClient.sendCommand()` retried empty responses with `Thread.sleep(1000)` — up to 10 rounds for the command loop, plus a second 10×1s loop for the capabilities handshake. These round-trips sit on the **interactive hot path**: every mouse click, key press, and status poll goes through `pressAKey()`/`QmpSender` → `sendCommand()`. One slow or momentarily empty QEMU response froze the user's tap for **up to ten seconds** (worst case both loops: 15+s), and the freeze also delayed every queued command behind it.

### 2. QEMU capability probe re-ran per start

`QemuManager.isSupportSetRefreshRate()` launched a full proot shell running `qemu-system-* -vnc help` (easily 1–3 s) **on every VM start**, and twice on snapshot-resume starts — all to learn a fact that cannot change while the app runs.

## Fix

- **Backoff retries**: 50 ms doubling per trial (`50, 100, 150, …`); handshake capped at 5 trials, command loop at 10. A dead QMP now gives up in under ~2 s total instead of 15+, and a transient hiccup costs milliseconds instead of seconds.
- **Capability cache**: `isSupportSetRefreshRate()` caches its answer per architecture in a static map (synchronized). First start pays the probe; every later start skips 1–3 s of shell work.

No behavioral change: the same responses are returned, just with tighter retry timing and one fewer redundant probe per start.