### PR TITLE
fix(shell-loader): use storePassword when loading the signing keystore

### DIFF
--- a/.zcode/plans/plan-sess_89847a92-3cb4-484f-ae7e-096e69b5ac4f.md
+++ b/.zcode/plans/plan-sess_89847a92-3cb4-484f-ae7e-096e69b5ac4f.md
@@ -1,0 +1,75 @@
+# M7：PAC 家族全语义修复 + 真实 XNU 推进验证
+
+**仓库**：`/Users/shiaho/Desktop/github/14/15/pocket-linux`，新分支 `fix/pac-auth-strip`（基于 main @ 78e0cbe）。
+
+## 背景探查结论（已核实到行号）
+
+XNU 卡死的根因链：`RETAA/RETAB` 在 cpu.cpp:435-462 被当作普通 RET 跳到**未剥位的脏 x30** → `fetch()` 守卫（cpu.cpp:185，top16 必须 0x0000/0xffff）拒绝 → 恢复逻辑又跳回同一个脏 x30（cpu.cpp:194）→ 死循环停摆。全家族还有 5 处缺陷：
+
+1. **XPACI 不剥位**（cpu.cpp:616-623 只在 bit10=1 时剥，而真实 XPACI `0xDAC143E0` bit10=0；仅 XPACD 偶然生效）
+2. **rn=31 的 Z 形指令读错寄存器**：PACIZA/AUTIZA 的输入是 rd 自身（无 Rn），当前代码 `xr(rn)` 读到 31 号寄存器恒 0 → A-key 指针被销毁为 0
+3. **BRAA `0xD71F`、BRAAZ、BLRAAZ 落空到 Exit::Inval**；BLRAA 虽然匹配 `0xD73F0000` 但跳转不剥位
+4. **PACGA 落空到 Inval**
+5. **ld/st 静默吞脏指针**（cpu.cpp:109/149：top16 非规范 → memset 0 返回成功）——一类隐藏数据损坏；fetch 恢复目标 x30 本身也可能是脏的
+6. **JIT 侧**：PACIASP 等提示空间 PAC（0xD50323xx/0xDAC1xxxx/PACGA）不在 `is_unsafe()` 过滤表里，会原样进入 native 块执行——`PACIASP` 会给宿主 x30（trampoline 尾地址）签名，块终止符 `BR x30` 直接跳飞。JIT 默认关，但这是同类地雷
+
+## 实施步骤
+
+### Step 0 — 经验确认 PAC 位布局（实现前先跑）
+构建并运行 `real_kc_test.cpp`（/tmp/kernelcache_vma2.bin 已在本地），利用现有 SPIN 停摆转储（打印 `frame ret=[x29+8]` 即已签名的返回地址）确认脏指针的实际位型。预期为 ARMv8.3+TBI 的"top-byte 模型"：PAC 占 bits 63:56，干净内核 VA 形如 `0xfffffe...`（bits 55:48 = 0xfe）。若实际数据不符，先修正 helper 常量再继续。
+
+### Step 1 — 共享剥位 helper（cpu.cpp 匿名命名空间）
+```cpp
+// auth=strip 模型：剥掉 top byte（PAC 字段），bit 55 为 1（内核高区）时
+// 回填 0xff 符号位。幂等：对干净指针（0xfffffe... / 0x0000...）无损。
+static inline uint64_t pac_strip(uint64_t v) {
+    uint64_t r = v & 0x00FFFFFFFFFFFFFFULL;
+    if (r & (1ULL << 55)) r |= 0xFF00000000000000ULL;
+    return r;
+}
+```
+（对 `0xffff0000_00000000` 别名区、`0xfffffe...` 内核区均已验证幂等。）
+
+### Step 2 — 解释器控制流修复
+- RETAA `0xD65F0BFF` / RETAB `0xD65F0FFF`：显式识别，`r_.pc = pac_strip(xr(30))`（普通 RET 保持不剥）
+- BLRAA 处理器（cpu.cpp:537）：目标剥位
+- 新增 BRAA/BRAAZ/BLRAAZ 处理（不再落 Inval），跳转目标剥位
+- fetch 恢复路径（cpu.cpp:194）：`x30` 剥位后再用
+
+### Step 3 — DP 家族与提示空间重写（cpu.cpp:616-623 及 516-536/714-726 之前插入特定处理器）
+- AUT{I,D}{A,B}（rn≠31）：`rd = pac_strip(xrn)`；PAC{I,D}{A,B}：保持 copy（sign 无法验证，copy 与 auth=strip 组合可无损往返）
+- rn=31 的 Z 形：**输入改读 `xr(rd)`**（修销毁 bug）；AUTIZ 剥位、PACIZ copy
+- XPACI/XPACD（bits[15:10] == 0b010000/0b010001）：无条件 `pac_strip`
+- PACGA `0x9AC23000` 族：`rd = xrn`（copy——保持"相同输入→相同输出"的相等性语义）
+- 提示空间：AUTIASP/AUTIBSP/AUTIAZ/AUTIBZ → 剥 x30；AUTIA1716/AUTIB1716 → 剥 x17；XPACLRI `0xD50320FF` → 剥 x30；对应 PAC 签名变体保持 no-op
+
+### Step 4 — 数据通路防御
+- `Cpu::ld/st`（cpu.cpp:108/148）：先 `va = pac_strip(va)` 再走 looks_bogus_ptr；仍 bogus 才按原逻辑吞掉（保留既有别名 hack 行为）
+- `Mmu::translate`（mmu.cpp:155）：入口剥位，TLB tag 用干净 VA
+
+### Step 5 — JIT 防雷（jit.cpp is_unsafe + jit_unsafe_test.cpp）
+过滤表新增：`0xDAC10000`（top16 DP-PAC）、`0x9AC23000`（PACGA）、提示空间 PACIASP 族（0xD503211F/0xD50323xx/0xD50320FF）。`jit_unsafe_test.cpp` 加对应测试向量。
+
+### Step 6 — 回归 guest（gen_pac_guest.py + asmutil.py 编码器 + check.sh）
+新增 guest 覆盖五条路径，UART 期望串（如 `PAZSD`）：
+- **P**：脏指针 → XPACI → BR 到函数打印 P
+- **A**：函数经 RETAA 返回（脏 x30）→ 调用方继续
+- **Z**：PACIZA→AUTIZA 往返，指针存活（修复前会变 0）
+- **S**：AUTIASP + XPACLRI + RET 链
+- **D**：经脏 top-byte 指针 ld，数据完好
+check.sh 加 `--expect` 行；harness.py 不动（无 PAC 解码，guest 走 host_run 路径）。
+
+### Step 7 — 双路验证
+1. `bash ddvm/tools/check.sh` → 全部 15 项 ALL PASS
+2. 构建 real_kc_test，跑 /tmp/kernelcache_vma2.bin → **指令数突破 2290 万停摆点**（M7 达成的唯一硬证据），记录新的停摆点/推进距离
+
+### Step 8 — 文档与提交
+- ddvm/README.md：记录 auth=strip 模型、M7 里程碑与新边界
+- 分支上提交（遵循仓库 Issue → PR → CI 规范，PR 待你确认后建）
+
+## 明确不做（M7 禁区）
+AIC/定时器真实化（M8）、JIT native 块扩宽（M11）、SMP、APFS 卷——全部留在主线计划里，不因顺手而提前。
+
+## 风险与预案
+- Step 0 数据若显示 PAC 不在 top-byte（如 bits 63:50），只改 helper 的两个常量，其余步骤不变
+- strip 后 XNU 若立即撞上新的未知设备访问（AIC 占位所致），那正是 M8 的入口，属预期进展而非回归

--- a/shell-loader/build.gradle
+++ b/shell-loader/build.gradle
@@ -37,7 +37,7 @@ androidComponents {
 
 def signingConfig = project(':app').android.signingConfigs.debug
 def keyStore = java.security.KeyStore.getInstance(java.security.KeyStore.getDefaultType())
-keyStore.load(new FileInputStream(signingConfig.storeFile), signingConfig.keyPassword.toCharArray())
+keyStore.load(new FileInputStream(signingConfig.storeFile), signingConfig.storePassword.toCharArray())
 
 android.defaultConfig.buildConfigField "String", "logTag", "\"Termux:X11 loader\""
 android.defaultConfig.buildConfigField "int", "SIGNATURE", String.valueOf(Arrays.hashCode(keyStore.getCertificate(signingConfig.keyAlias).getEncoded()))


### PR DESCRIPTION
## What

In `shell-loader/build.gradle`, the `KeyStore.load()` call passes `signingConfig.keyPassword` as the **store** password:

```groovy
keyStore.load(new FileInputStream(signingConfig.storeFile), signingConfig.keyPassword.toCharArray())
```

`KeyStore.load(InputStream, char[])` expects the keystore's integrity/store password, not the key password.

## Why it matters

This only works today because `testkey.jks` uses the same password for both (`856856`). As soon as the store and key passwords differ — which is the case for the CI secrets setup (`KEYSTORE_PASSWORD` / `KEY_PASSWORD`) described in `app/build.gradle`'s `keystore.properties` override mechanism — configuring the `:shell-loader` project throws `IOException: keystore password was incorrect` and the whole build fails.

## Fix

One line: pass `signingConfig.storePassword` instead.

## Verification

`:shell-loader:assembleDebug` builds successfully with the change.