### PR TITLE
fix(settings): remove redundant setContentView in five settings activities

### DIFF
--- a/app/src/main/java/com/vectras/vm/settings/FilePickerSettingsActivity.java
+++ b/app/src/main/java/com/vectras/vm/settings/FilePickerSettingsActivity.java
@@ -21,7 +21,6 @@ public class FilePickerSettingsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
-        setContentView(R.layout.activity_external_vnc_settings);
         binding = ActivityFilePickerSettingsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
         setSupportActionBar(binding.toolbar);

--- a/app/src/main/java/com/vectras/vm/settings/ThemeActivity.java
+++ b/app/src/main/java/com/vectras/vm/settings/ThemeActivity.java
@@ -31,7 +31,6 @@ public class ThemeActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
-        setContentView(R.layout.activity_external_vnc_settings);
         binding = ActivityThemeBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
         setSupportActionBar(binding.toolbar);

--- a/app/src/main/java/com/vectras/vm/settings/UpdaterActivity.java
+++ b/app/src/main/java/com/vectras/vm/settings/UpdaterActivity.java
@@ -64,7 +64,6 @@ public class UpdaterActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
-        setContentView(R.layout.activity_external_vnc_settings);
         binding = ActivityUpdaterBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
         setSupportActionBar(binding.toolbar);

--- a/app/src/main/java/com/vectras/vm/settings/VNCSettingsActivity.java
+++ b/app/src/main/java/com/vectras/vm/settings/VNCSettingsActivity.java
@@ -23,7 +23,6 @@ public class VNCSettingsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
-        setContentView(R.layout.activity_external_vnc_settings);
         binding = ActivityVncSettingsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
         setSupportActionBar(binding.toolbar);

--- a/app/src/main/java/com/vectras/vm/settings/X11DisplaySettingsActivity.java
+++ b/app/src/main/java/com/vectras/vm/settings/X11DisplaySettingsActivity.java
@@ -26,7 +26,6 @@ public class X11DisplaySettingsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
-        setContentView(R.layout.activity_external_vnc_settings);
         binding = ActivityX11DisplaySettingsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
         setSupportActionBar(binding.toolbar);


### PR DESCRIPTION
## What

Five settings activities inflate the **wrong** layout first and immediately replace it with their own ViewBinding root:

```java
EdgeToEdge.enable(this);
setContentView(R.layout.activity_external_vnc_settings);   // ← wrong layout, discarded instantly
binding = ActivityVncSettingsBinding.inflate(getLayoutInflater());
setContentView(binding.getRoot());
```

Affected: `VNCSettingsActivity`, `UpdaterActivity`, `FilePickerSettingsActivity`, `X11DisplaySettingsActivity`, `ThemeActivity` — all copy-pasted from `ExternalVNCSettingsActivity`, which is the only activity that actually uses `activity_external_vnc_settings`.

## Why it matters

The stray call inflates a full layout tree on every open just to throw it away — wasted work on every visit to these screens (and confusing to anyone reading the code).

## Fix

Delete the redundant `setContentView(R.layout.activity_external_vnc_settings)` line in each activity. One line removed per file, no behavior change.

## Verification

`:app:compileDebugJavaWithJavac` builds successfully.