### PR TITLE
ci(pr-build): remove duplicate Create google-services.json step

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Create google-services.json
-        run: echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > app/google-services.json
-
       - name: Create Dummy Keystore
         run: |
           RANDOM_PASS=$(openssl rand -base64 12 | tr -dc 'a-zA-Z0-9')


### PR DESCRIPTION
## What

`pr-build.yml` had **two** steps named `Create google-services.json`:

1. **Step 1** (early): `echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > app/google-services.json` — unconditionally decodes the secret. For fork PRs (no secrets), this writes an **empty** `google-services.json`, which the Google Services plugin would then fail on.
2. **Step 2** (later, right before the build): already handles both cases — decode the secret when present, otherwise write the placeholder `google-services.json` with a fake API key that lets the build succeed without Firebase.

## Fix

Delete the redundant first step. The placeholder-aware second step (which the file's own header comment describes) now owns the whole responsibility.

## Verification

YAML structure verified; the remaining step is the one that runs immediately before `Build Debug APK`.