### PR TITLE
chore(deps): remove unused and duplicated dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,7 +110,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation libs.androidx.appcompat
     implementation libs.material
     implementation libs.androidx.annotation
@@ -125,15 +124,10 @@ dependencies {
     implementation libs.firebase.messaging
     implementation libs.guava
     implementation libs.gson
-    implementation libs.androidx.window
-    implementation libs.commons.io
-    implementation libs.lottie
     implementation libs.commons.compress
     implementation libs.androidx.activity.ktx
     implementation libs.androidx.constraintlayout
-    implementation libs.androidx.preference.ktx
     implementation libs.androidx.documentfile
-    implementation libs.androidx.core.ktx
     compileOnly project(':shell-loader:stub')
     implementation project(":terminal-view")
     
@@ -144,11 +138,6 @@ dependencies {
     // Glide
     implementation libs.glide
     annotationProcessor libs.compiler
-    
-    // Test dependencies
-    testImplementation libs.junit
-    androidTestImplementation libs.androidx.junit
-    androidTestImplementation libs.androidx.espresso.core
 
     implementation libs.play.services.oss.licenses
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,30 +3,24 @@ activityKtx = "1.13.0"
 annotation = "1.10.0"
 appcompat = "1.8.0"
 commonsCompress = "1.28.0"
-commonsIo = "2.22.0"
 constraintlayout = "2.2.2"
 coreKtx = "1.19.0"
 documentfile = "1.1.0"
 drawerlayout = "1.2.0"
-espressoCore = "3.7.0"
 firebaseBom = "34.18.0"
 firebaseCrashlyticsGradle = "3.0.8"
-firebaseMessaging = "25.1.2"
 glide = "5.0.9"
 googleServices = "4.5.0"
 gradle = "9.4.0"
 gson = "2.14.0"
 guava = "33.7.1-jre"
 junit = "4.13.2"
-junitVersion = "1.3.0"
 kotlinGradlePlugin = "2.4.10"
-lottie = "6.7.1"
 material = "1.14.0"
 preferenceKtx = "1.2.1"
 retrofit2 = "3.0.0"
 swiperefreshlayout = "1.2.0"
 viewpager = "1.1.0"
-window = "1.5.1"
 playServicesOssLicensesPlugin = "0.13.0"
 playServicesOssLicenses = "17.3.0"
 
@@ -38,19 +32,15 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-documentfile = { group = "androidx.documentfile", name = "documentfile", version.ref = "documentfile" }
 androidx-drawerlayout = { group = "androidx.drawerlayout", name = "drawerlayout", version.ref = "drawerlayout" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preferenceKtx" }
 androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "swiperefreshlayout" }
 androidx-viewpager = { group = "androidx.viewpager", name = "viewpager", version.ref = "viewpager" }
-androidx-window = { group = "androidx.window", name = "window", version.ref = "window" }
 commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commonsCompress" }
-commons-io = { group = "commons-io", name = "commons-io", version.ref = "commonsIo" }
 compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "glide" }
 converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit2" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-crashlytics-gradle = { group = "com.google.firebase", name = "firebase-crashlytics-gradle", version.ref = "firebaseCrashlyticsGradle" }
-firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging", version.ref = "firebaseMessaging" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
@@ -60,7 +50,6 @@ gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
-lottie = { group = "com.airbnb.android", name = "lottie", version.ref = "lottie" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit2" }
 play-services-oss-licenses-plugin = { group = "com.google.android.gms", name = "oss-licenses-plugin", version.ref = "playServicesOssLicensesPlugin" }


### PR DESCRIPTION
## What

**app/build.gradle:**
- **Drop `androidx.window`, `commons-io`, `lottie`** — zero references in Java sources, layouts, or resources (verified by full-text search)
- **Remove duplicated** `androidx.preference.ktx` (declared twice) and `androidx.core.ktx` (also twice)
- **Remove `junit`/`espresso`/`androidx-junit` test deps** — `:app` has no `src/test` or `src/androidTest` sources (`:terminal-emulator` and `:terminal-view` keep their own `junit` test deps)
- **Remove `fileTree('libs')`** — `app/libs` does not exist

**gradle/libs.versions.toml:**
- **Let `firebase-bom` manage `firebase-messaging`** instead of pinning `25.1.2`, which silently overrode the BOM version
- Prune unused version refs and catalog entries (`window`, `commonsIo`, `lottie`, `espressoCore`, `junitVersion`, `firebaseMessaging`)

## Verification

`:app:compileDebugJavaWithJavac` builds successfully after the cleanup.
