### PR TITLE
chore(manifest): remove permissions and feature the app never uses

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,16 +4,12 @@
     package="com.vectras.vm">
 
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission
-        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
-        tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
@@ -22,7 +18,6 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
@@ -40,9 +35,6 @@
 
     <uses-feature
         android:name="android.hardware.touchscreen"
-        android:required="false" />
-    <uses-feature
-        android:name="android.hardware.microphone"
         android:required="false" />
 
     <application


### PR DESCRIPTION
## What

Remove three permissions and one feature declaration from `AndroidManifest.xml` that the app never uses:

- **`RECORD_AUDIO`** — no `AudioRecord`/`MediaRecorder` usage anywhere in code. The `uses-feature android.hardware.microphone` declaration is also removed for consistency.
- **`MANAGE_EXTERNAL_STORAGE`** — no `ACTION_MANAGE_ALL_FILES_ACCESS` or `isExternalStorageManager` call anywhere in code.
- **`SYSTEM_ALERT_WINDOW`** — never referenced in code.

Removing unused permissions shrinks the Play Store privacy declaration and reduces user friction at install time. If microphone passthrough to QEMU is added later, `RECORD_AUDIO` can simply be re-added.

## Verification

`:app:compileDebugJavaWithJavac` builds successfully after the manifest cleanup.
