### PR TITLE
build(app): make generatePrefs/generateShortcuts proper incremental tasks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -153,10 +153,15 @@ dependencies {
     implementation libs.play.services.oss.licenses
 }
 
-afterEvaluate {
-    tasks.register("generatePrefs") {
+def generatePrefs = tasks.register("generatePrefs") {
+    def prefsXml = file('src/main/res/xml/preferences_x11.xml')
+    def out = file('build/generated/java/com/vectras/vm/x11/Prefs.java')
+    inputs.file(prefsXml)
+    outputs.file(out)
+
+    doLast {
         //noinspection UnnecessaryQualifiedReference
-        def xml = groovy.xml.DOMBuilder.parse((new StringReader(file('src/main/res/xml/preferences_x11.xml').text)))
+        def xml = groovy.xml.DOMBuilder.parse((new StringReader(prefsXml.text)))
         def preferenceNodes = xml.documentElement.getElementsByTagName("*")
         def preferences = []
 
@@ -176,7 +181,6 @@ afterEvaluate {
                 preferences << [ type: 'Boolean',  key: node.getAttribute("app:key"), default: node.getAttribute("app:defaultValue") ]
         }
 
-        def out = file('build/generated/java/com/vectras/vm/x11/Prefs.java')
         out.getParentFile().exists() || out.getParentFile().mkdirs()
         out.delete()
         out.createNewFile()
@@ -213,18 +217,25 @@ afterEvaluate {
         out << '  }\n'
         out << '}\n'
     }
-    android.sourceSets.main.java.srcDirs += 'build/generated/java'
-    preBuild.dependsOn generatePrefs
+}
+android.sourceSets.main.java.srcDirs += 'build/generated/java'
+preBuild.dependsOn generatePrefs
 
-    tasks.register("generateShortcuts") {
-        def out = file('build/generated/templateRes/xml/shortcuts.xml')
+def generateShortcuts = tasks.register("generateShortcuts") {
+    def template = file('src/main/templates/xml/shortcuts.xml')
+    def out = file('build/generated/templateRes/xml/shortcuts.xml')
+    inputs.file(template)
+    inputs.property('applicationId', android.defaultConfig.applicationId)
+    outputs.file(out)
+
+    doLast {
         out.getParentFile().exists() || out.getParentFile().mkdirs()
-        out.text = file('src/main/templates/xml/shortcuts.xml').text
+        out.text = template.text
                 .replace('@@APPLICATION_ID@@', android.defaultConfig.applicationId)
     }
-    android.sourceSets.main.res.srcDirs += 'build/generated/templateRes'
-    preBuild.dependsOn generateShortcuts
 }
+android.sourceSets.main.res.srcDirs += 'build/generated/templateRes'
+preBuild.dependsOn generateShortcuts
 
 tasks.register('buildShellLoaderDebug', DefaultTask) {
     dependsOn ':shell-loader:assembleDebug'


### PR DESCRIPTION
## What

The `generatePrefs` and `generateShortcuts` code-generation tasks in `app/build.gradle` had their generation logic written **directly in the task configuration closure** inside `afterEvaluate`. That means the logic ran at **configuration time** on every Gradle invocation (even `gradle help`) — unconditionally deleting and rewriting `Prefs.java` and `shortcuts.xml`. With no declared inputs/outputs, the tasks were never up-to-date, and the rewritten `Prefs.java` forced full javac recompilation of the app sources on every build.

## Fix

- Move task registration out of `afterEvaluate` (the android extension is already configured at that point)
- Wrap the generation logic in `doLast` so it runs at execution time
- Declare `inputs.file` / `outputs.file` (plus an `applicationId` input property for `generateShortcuts`) so Gradle can skip the tasks when nothing changed

## Verification

- First `:app:generatePrefs` run executes; **second run is `UP-TO-DATE`** (skipped)
- Generated `Prefs.java` content is unchanged (52 preference fields, identical output)
- `:app:compileDebugJavaWithJavac` builds successfully
