### PR TITLE
fix(security): redact VNC password from command-line logging

### DIFF
--- a/app/src/main/java/com/vectras/vm/CqcmActivity.java
+++ b/app/src/main/java/com/vectras/vm/CqcmActivity.java
@@ -20,6 +20,7 @@ import com.vectras.vm.main.core.PendingCommand;
 import com.vectras.vm.utils.FileUtils;
 import com.vectras.vm.utils.JSONUtils;
 import com.vectras.vm.utils.PermissionUtils;
+import com.vectras.vm.utils.TextUtils;
 import com.vectras.vm.utils.UIUtils;
 
 import java.util.HashMap;
@@ -120,7 +121,7 @@ public class CqcmActivity extends AppCompatActivity {
     }
 
     private void runCommand(String _command) {
-        Log.i(TAG, "runCommand: " + _command);
+        Log.i(TAG, "runCommand: " + TextUtils.redactSecrets(_command));
 
         PendingCommand.command = _command;
 

--- a/app/src/main/java/com/vectras/vm/StartVM.java
+++ b/app/src/main/java/com/vectras/vm/StartVM.java
@@ -22,6 +22,7 @@ import com.vectras.vm.settings.SettingsData;
 import com.vectras.vm.utils.CpuHelper;
 import com.vectras.vm.utils.DeviceUtils;
 import com.vectras.vm.utils.FileUtils;
+import com.vectras.vm.utils.TextUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ public class StartVM {
                 snapshotParams += " " + getDisplayParams(activity, vmConfigs.itemExtra);
                 if (!snapshotParams.contains("-incoming defer"))
                     snapshotParams += " -incoming defer";
-                Log.d("StartVM.env", snapshotParams);
+                Log.d("StartVM.env", TextUtils.redactSecrets(snapshotParams));
 
                 FileUtils.copyFile(VmFileManager.getPath(vmConfigs.vmID, VmFileManager.COMPILED_BATERRY_ACPI_FILE_NAME), VmFileManager.getTempPath(activity, vmConfigs.vmID));
                 FileUtils.copyFile(VmFileManager.getPath(vmConfigs.vmID, VmFileManager.COMPILED_WIFI_CARD_ACPI_FILE_NAME), VmFileManager.getTempPath(activity, vmConfigs.vmID));

--- a/app/src/main/java/com/vectras/vm/VMManager.java
+++ b/app/src/main/java/com/vectras/vm/VMManager.java
@@ -876,7 +876,7 @@ public class VMManager {
     }
 
     public static boolean isthiscommandsafe(@NonNull String _command, Context _context) {
-        Log.d(TAG, "isthiscommandsafe: " + _command);
+        Log.d(TAG, "isthiscommandsafe: " + TextUtils.redactSecrets(_command));
 
         // The command is written to a bash shell's stdin, so characters that
         // trigger shell expansion, redirection, or process substitution let a

--- a/app/src/main/java/com/vectras/vm/core/ShellExecutor.java
+++ b/app/src/main/java/com/vectras/vm/core/ShellExecutor.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import com.termux.app.TermuxService;
 import com.vectras.vm.AppConfig;
 import com.vectras.vm.logger.VectrasStatus;
+import com.vectras.vm.utils.TextUtils;
 import java.io.BufferedReader;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -38,8 +39,8 @@ public class ShellExecutor {
 
                 OutputStream outputStream = shellExecutorProcess.getOutputStream();
 
-                Log.d(TAG, "Running command: " + command);
-                logWriter.write("Running command: " + command + "\n");
+                Log.d(TAG, "Running command: " + TextUtils.redactSecrets(command));
+                logWriter.write("Running command: " + TextUtils.redactSecrets(command) + "\n");
                 outputStream.write((command + "\n").getBytes());
                 outputStream.flush();
 

--- a/app/src/main/java/com/vectras/vm/main/core/MainStartVM.java
+++ b/app/src/main/java/com/vectras/vm/main/core/MainStartVM.java
@@ -32,6 +32,7 @@ import com.vectras.vm.utils.FileUtils;
 import com.vectras.vm.utils.NetworkUtils;
 import com.vectras.vm.utils.PackageUtils;
 import com.vectras.vm.utils.ServiceUtils;
+import com.vectras.vm.utils.TextUtils;
 
 import java.io.File;
 
@@ -378,7 +379,7 @@ public class MainStartVM {
             finalCommand = "export DISPLAY=:0 && " + finalCommand;
             DisplaySystem.startDesktop(context);
         }
-        Log.i(TAG, finalCommand);
+        Log.i(TAG, TextUtils.redactSecrets(finalCommand));
 
         if (breakNow) {
             dismissDialog();

--- a/app/src/main/java/com/vectras/vm/main/core/PendingCommand.java
+++ b/app/src/main/java/com/vectras/vm/main/core/PendingCommand.java
@@ -14,6 +14,7 @@ import com.vectras.vm.VMManager;
 import com.vectras.vm.manager.VmFileManager;
 import com.vectras.vm.utils.DialogUtils;
 import com.vectras.vm.utils.FileUtils;
+import com.vectras.vm.utils.TextUtils;
 import com.vectras.vterm.Terminal2;
 
 public class PendingCommand {
@@ -22,7 +23,7 @@ public class PendingCommand {
 
     public static void runNow(Activity activity) {
         if (command != null && !command.isEmpty()) {
-            Log.d(TAG, "runNow: " + command);
+            Log.d(TAG, "runNow: " + TextUtils.redactSecrets(command));
 
             if (!VMManager.isthiscommandsafe(command, activity)) {
                 DialogUtils.oneDialog(

--- a/app/src/main/java/com/vectras/vm/utils/TextUtils.java
+++ b/app/src/main/java/com/vectras/vm/utils/TextUtils.java
@@ -8,6 +8,20 @@ import com.vectras.vm.R;
 import java.util.Random;
 
 public class TextUtils {
+
+    /**
+     * Masks the value of QEMU "-object secret,id=...,data=..." options so command
+     * lines can be logged without leaking secrets such as the external VNC
+     * password. Handles the backslash escapes (\, \", \,) that
+     * StartVM.getDisplayParams applies to the password.
+     */
+    public static String redactSecrets(String text) {
+        if (text == null) {
+            return null;
+        }
+        return text.replaceAll("data=\"(?:[^\"\\\\]|\\\\.)*\"", "data=\"***\"");
+    }
+
     public static boolean isNumberOnly(String content) {
         return content.matches("\\d+");
     }

--- a/app/src/main/java/com/vectras/vterm/Terminal2.java
+++ b/app/src/main/java/com/vectras/vterm/Terminal2.java
@@ -10,6 +10,7 @@ import com.vectras.vm.R;
 import com.vectras.vm.logger.VectrasStatus;
 import com.vectras.vm.utils.FileUtils;
 import com.vectras.vm.utils.ProgressDialog;
+import com.vectras.vm.utils.TextUtils;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -200,6 +201,7 @@ public class Terminal2 {
             String line;
             while ((line = reader.readLine()) != null) {
 //                Log.d(TAG, line);
+                line = TextUtils.redactSecrets(line);
                 VectrasStatus.logError(line);
                 output.append(line).append("\n");
                 if (callback != null) callback.onRunning(command, line);


### PR DESCRIPTION
## What

When external VNC is enabled with a password, the full QEMU command line embeds the secret in plain text:

```
-object secret,id=vncpass,data="userPassword"
```

This command line was logged **unredacted** at several sites:

- `MainStartVM.java:381` — the final assembled command (`Log.i`)
- `StartVM.java:51` — snapshot-resume params (`Log.d`)
- `VMManager.java:879` — every command checked by `isthiscommandsafe` (`Log.d`)
- `PendingCommand.java:25` — commands pushed via intent (`Log.d`)
- `CqcmActivity.java:123` — commands from the Params Notebook bridge (`Log.i`)
- `ShellExecutor.java:41-42` — command echoed to logcat **and** `shell-executor.log`
- `Terminal2.java:203` — every process output line fed to `VectrasStatus` (and potentially to crash-report uploads)

Anyone with logcat access, or anyone receiving a shared crash report, could recover the VNC password guarding the TCP listener on port 5900+.

## Fix

Add `TextUtils.redactSecrets()` which masks `data="..."` values (handling the `\`, `\"`, `\,` backslash escapes that `getDisplayParams` applies to the password), and apply it at each logging site. The command actually executed by QEMU is unchanged — only the log output is masked.

## Verification

`:app:compileDebugJavaWithJavac` builds successfully. The regex handles escaped characters produced by the password escaping logic in `StartVM.getDisplayParams()`.
