### PR TITLE
fix(security): reject unverified callers in CqcmActivity instead of accepting only them

### DIFF
--- a/app/src/main/java/com/vectras/vm/CqcmActivity.java
+++ b/app/src/main/java/com/vectras/vm/CqcmActivity.java
@@ -57,7 +57,9 @@ public class CqcmActivity extends AppCompatActivity {
         Log.i("CqcmActivity", "Checking access to storage...");
         if (!PermissionUtils.storagepermission(this,false)) return;
 
-        if (ParamNotebookVerifier.verify(this)) {
+        // Only the signature-verified Param Notebook may proceed; everyone
+        // else (including callers with no verifiable calling package) is rejected.
+        if (!ParamNotebookVerifier.verify(this)) {
             Toast.makeText(getApplicationContext(), "Cannot continue due to an invalid source.", Toast.LENGTH_LONG).show();
             finish();
             return;


### PR DESCRIPTION
## What

`CqcmActivity.onResume()` calls `ParamNotebookVerifier.verify(this)`, which returns `true` only when the calling package is the signature-verified Param Notebook companion app. The surrounding `if` condition was inverted: the activity showed "Cannot continue due to an invalid source." and finished when the caller **was** the legitimate, signature-verified Param Notebook — and let every other caller proceed.

Since `CqcmActivity` is `android:exported="true"` and its intent extras feed downstream command execution and VM-config replacement (`PendingCommand` / `VmEditor`), this inversion weakened an access-control check that the verifier's own comment describes as relying on `startActivityForResult` caller identity.

## Fix

Invert the condition to match `ParamNotebookVerifier.verify()`'s documented semantics ("reject unless the caller is the verified Param Notebook") and add a comment explaining the intended allowlist so the condition is not flipped back by mistake.

## Notes

- Given the security-sensitive nature, we are happy to share further details privately with the maintainer before this is merged or publicly discussed.
- Happy to also restrict this activity behind an explicit signature-level permission if preferred — that is a larger change and can be a follow-up.

## Verification

`:app:compileDebugJavaWithJavac` builds successfully with the change.
