### PR TITLE
fix(security): validate vmID before using it in paths and shell commands

### DIFF
--- a/app/src/main/java/com/anbui/elephant/vm/VmEditor.java
+++ b/app/src/main/java/com/anbui/elephant/vm/VmEditor.java
@@ -25,6 +25,7 @@ public class VmEditor {
         if (!JSONUtils.isValidFromFile(AppConfig.romsdatajson))  return false;
 
         String vmIdReady = vmId.isEmpty() ? VMManager.idGenerator() : vmId;
+        if (!VmFileManager.isValidVmId(vmIdReady)) return false;
         if (!forceCreate && VMManager.isVMExist(vmIdReady)) {
             if (!VMManager.replaceToVMList(-1, vmIdReady , vmConfig)) return false;
         } else {

--- a/app/src/main/java/com/vectras/vm/VMManager.java
+++ b/app/src/main/java/com/vectras/vm/VMManager.java
@@ -288,6 +288,7 @@ public class VMManager {
     }
 
     public static boolean writeToVMConfig(String vmID, String content) {
+        if (!VmFileManager.isValidVmId(vmID)) return false;
         return FileUtils.writeToFile(AppConfig.maindirpath + "/roms/" + vmID, "rom-data.json", content.replace("\\u003d", "=")) &&
                 FileUtils.writeToFile(AppConfig.maindirpath + "/roms/" + vmID, "vmID.txt", vmID);
         // TODO: vmID.txt can be removed, it is being retained for backward compatibility.

--- a/app/src/main/java/com/vectras/vm/creator/VMCreatorActivity.java
+++ b/app/src/main/java/com/vectras/vm/creator/VMCreatorActivity.java
@@ -367,7 +367,7 @@ public class VMCreatorActivity extends AppCompatActivity {
                     if (createVMFolder(true)) {
                         Terminal2 terminal2 = new Terminal2(this);
                         terminal2.setShowProgressDialog(true);
-                        terminal2.execute("qemu-img create -f qcow2 " + VmFileManager.getPath(vmID, "disk.qcow2") + " 128G", new Terminal2.Terminal2Callback() {
+                        terminal2.execute("qemu-img create -f qcow2 '" + VmFileManager.getPath(vmID, "disk.qcow2") + "' 128G", new Terminal2.Terminal2Callback() {
                             @Override
                             public void onRunning(String command, String newLine) {
                                 // Nothing to do.
@@ -1051,6 +1051,10 @@ public class VMCreatorActivity extends AppCompatActivity {
                 if (jObj.has("vmID")) {
                     if (!jObj.isNull("vmID")) {
                         if (!jObj.getString("vmID").isEmpty()) {
+                            if (!VmFileManager.isValidVmId(jObj.getString("vmID"))) {
+                                DialogUtils.oneDialog(this, getResources().getString(R.string.oops), getResources().getString(R.string.error_CR_CVBI4), getResources().getString(R.string.ok), true, R.drawable.warning_48px, true, null, null);
+                                return;
+                            }
                             FileUtils.move(VmFileManager.getConfigFile(vmID), VmFileManager.getConfigFile(jObj.getString("vmID")));
                             vmID = jObj.getString("vmID");
                         }

--- a/app/src/main/java/com/vectras/vm/manager/BatteryEmulatorManager.java
+++ b/app/src/main/java/com/vectras/vm/manager/BatteryEmulatorManager.java
@@ -51,7 +51,7 @@ public class BatteryEmulatorManager {
             FileUtils.writeToFile(vmTemp.getAbsolutePath(), "battery.asl", batteryAsl);
 
             if (FileUtils.isFileExists(VmFileManager.getTempPath(context, vmId, "battery.asl"))) {
-                String respond = new Terminal2(context).executeOnThisThread("cd " + vmTemp.getAbsolutePath() + " && iasl battery.asl && echo Compiled");
+                String respond = new Terminal2(context).executeOnThisThread("cd '" + vmTemp.getAbsolutePath() + "' && iasl battery.asl && echo Compiled");
                 //Log.d(TAG, respond);
                 return respond.contains("Compiled");
             } else {

--- a/app/src/main/java/com/vectras/vm/manager/VmFileManager.java
+++ b/app/src/main/java/com/vectras/vm/manager/VmFileManager.java
@@ -8,6 +8,7 @@ import com.vectras.vm.utils.FileUtils;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 public class VmFileManager {
     private static final String TAG = "VmFileManager";
@@ -30,6 +31,22 @@ public class VmFileManager {
     public static final String PENDING_ADD_SUFFIX = "_add_";
     public static final String OPTICAL_DISC_0 = "OpticalDisc0.iso";
     public static final String OPTICAL_DISC_1 = "OpticalDisc1.iso";
+
+    // App-generated vmIDs are letters and digits (see VMManager.startRamdomVMID),
+    // and the hidden-VM marker prepends "_" (HIDE_VM_SUFFIX). Anything outside
+    // this set could escape the VM folder ("..", "/") or inject shell
+    // metacharacters into commands built from these paths.
+    private static final Pattern VALID_VM_ID = Pattern.compile("^[A-Za-z0-9_-]+$");
+
+    public static boolean isValidVmId(String vmId) {
+        return vmId != null && VALID_VM_ID.matcher(vmId).matches();
+    }
+
+    private static String requireValidVmId(String vmId) {
+        if (!isValidVmId(vmId))
+            throw new IllegalArgumentException("Invalid vmId: " + vmId);
+        return vmId;
+    }
 
 
     public static boolean hide(String vmId) {
@@ -91,7 +108,8 @@ public class VmFileManager {
                 FileUtils.delete(fileList.get(position));
         }
 
-        removeTemp(context, "");
+        // Clear the shared temp root (no vmId) as well.
+        FileUtils.delete(tempRoot(context).getAbsolutePath());
     }
 
     public static boolean isInUse(String vmId) {
@@ -104,22 +122,22 @@ public class VmFileManager {
     }
 
     public static String getPath(String vmId) {
-        String path = new File(AppConfig.vmFolder, vmId).getAbsolutePath();
+        String path = new File(AppConfig.vmFolder, requireValidVmId(vmId)).getAbsolutePath();
         FileUtils.createDirectory(path);
         return path + "/";
     }
 
     public static String getPathHide(String vmId) {
-        String path = new File(AppConfig.vmFolder, HIDE_VM_SUFFIX + vmId).getAbsolutePath();
+        String path = new File(AppConfig.vmFolder, HIDE_VM_SUFFIX + requireValidVmId(vmId)).getAbsolutePath();
         return path + "/";
     }
 
     public static String quickGetPath(String vmId) {
-        return new File(AppConfig.vmFolder, vmId).getAbsolutePath();
+        return new File(AppConfig.vmFolder, requireValidVmId(vmId)).getAbsolutePath();
     }
 
     public static String quickGetPathHide(String vmId) {
-        return new File(AppConfig.vmFolder, HIDE_VM_SUFFIX + vmId).getAbsolutePath();
+        return new File(AppConfig.vmFolder, HIDE_VM_SUFFIX + requireValidVmId(vmId)).getAbsolutePath();
     }
 
     public static boolean delete(Context context, String vmId) {
@@ -163,11 +181,14 @@ public class VmFileManager {
         return new File(getTempPath(context, vmId), childFilePath).getAbsolutePath();
     }
 
-    public static String getTempPath(Context context, String vmId) {
+    private static File tempRoot(Context context) {
         File externalCacheDir = context.getExternalCacheDir();
-        String cachePath = externalCacheDir != null ? externalCacheDir.getAbsolutePath() : context.getCacheDir().getAbsolutePath();
+        File cacheDir = externalCacheDir != null ? externalCacheDir : context.getCacheDir();
+        return new File(cacheDir, "temp");
+    }
 
-        String path = new File(cachePath, "temp/" + vmId).getAbsolutePath();
+    public static String getTempPath(Context context, String vmId) {
+        String path = new File(tempRoot(context), requireValidVmId(vmId)).getAbsolutePath();
         FileUtils.createDirectory(path);
         return path + "/";
     }
@@ -177,7 +198,7 @@ public class VmFileManager {
     }
 
     public static String getInternalTempPath(Context context, String vmId) {
-        String path = new File(context.getCacheDir().getAbsolutePath(), "temp/" + vmId).getAbsolutePath();
+        String path = new File(new File(context.getCacheDir(), "temp"), requireValidVmId(vmId)).getAbsolutePath();
         FileUtils.createDirectory(path);
         return path + "/";
     }

--- a/app/src/main/java/com/vectras/vm/manager/WifiCardEmulatorManager.java
+++ b/app/src/main/java/com/vectras/vm/manager/WifiCardEmulatorManager.java
@@ -22,7 +22,7 @@ public class WifiCardEmulatorManager {
             FileUtils.writeToFile(vmTemp.getAbsolutePath(), "wifi.asl", wifiAsl);
 
             if (FileUtils.isFileExists(VmFileManager.getTempPath(context, vmId, "wifi.asl"))) {
-                String respond = new Terminal2(context).executeOnThisThread("cd " + vmTemp.getAbsolutePath() + " && iasl wifi.asl && echo Compiled");
+                String respond = new Terminal2(context).executeOnThisThread("cd '" + vmTemp.getAbsolutePath() + "' && iasl wifi.asl && echo Compiled");
                 //Log.d(TAG, respond);
                 return respond.contains("Compiled");
             } else {


### PR DESCRIPTION
## What

`vmID` values coming from imported `.cvbi` configs (and VM configs pushed through the Params Notebook bridge) were used unsanitized to build filesystem paths and shell commands:

- `VmFileManager.getPath` / `getTempPath` and friends interpolated `vmID` directly — a `vmID` containing `../` escapes the VM folder, including into recursive-delete and file-write paths (`FileUtils.delete`, `FileUtils.move`).
- `BatteryEmulatorManager` / `WifiCardEmulatorManager` ran `cd <vmTemp> && iasl ...` with the vmID-derived path **unquoted**.

## Changes

- **`VmFileManager`**: add `isValidVmId()` (letters, digits, `_`, `-` — matching app-generated IDs and the hidden-VM `_` prefix) and fail fast in every path-construction method via `requireValidVmId()`. This is the single choke point for all downstream file/shell use.
- **`quickCleanUp`** now clears the shared temp root via a dedicated `tempRoot()` helper instead of passing an empty `vmID` (which the new validation would reject).
- **`VMCreatorActivity` `.cvbi` import**: reject an invalid `vmID` with the standard error dialog instead of moving folders outside the VM directory.
- **`VmEditor`**: reject an invalid `vmID` instead of writing configs with it.
- **`VMManager.writeToVMConfig`**: reject an invalid `vmID` (this writer bypassed `VmFileManager` path construction with raw string concatenation).
- **Shell quoting**: quote the working directory in the `iasl` shell commands and the `qemu-img create` command as defense in depth.

## Notes

- Given the security-sensitive nature, we are happy to share further details privately with the maintainer before this is merged or publicly discussed.
- App-generated IDs (letters/digits from `startRamdomVMID`, `_` hidden prefix) are unaffected; only IDs containing path/shell metacharacters are rejected.

## Verification

`:app:compileDebugJavaWithJavac` builds successfully with the changes.
