### PR TITLE
build(app): make generatePrefs/generateShortcuts proper incremental tasks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -153,10 +153,15 @@ dependencies {
     implementation libs.play.services.oss.licenses
 }
 
-afterEvaluate {
-    tasks.register("generatePrefs") {
+def generatePrefs = tasks.register("generatePrefs") {
+    def prefsXml = file('src/main/res/xml/preferences_x11.xml')
+    def out = file('build/generated/java/com/vectras/vm/x11/Prefs.java')
+    inputs.file(prefsXml)
+    outputs.file(out)
+
+    doLast {
         //noinspection UnnecessaryQualifiedReference
-        def xml = groovy.xml.DOMBuilder.parse((new StringReader(file('src/main/res/xml/preferences_x11.xml').text)))
+        def xml = groovy.xml.DOMBuilder.parse((new StringReader(prefsXml.text)))
         def preferenceNodes = xml.documentElement.getElementsByTagName("*")
         def preferences = []
 
@@ -176,7 +181,6 @@ afterEvaluate {
                 preferences << [ type: 'Boolean',  key: node.getAttribute("app:key"), default: node.getAttribute("app:defaultValue") ]
         }
 
-        def out = file('build/generated/java/com/vectras/vm/x11/Prefs.java')
         out.getParentFile().exists() || out.getParentFile().mkdirs()
         out.delete()
         out.createNewFile()
@@ -213,18 +217,25 @@ afterEvaluate {
         out << '  }\n'
         out << '}\n'
     }
-    android.sourceSets.main.java.srcDirs += 'build/generated/java'
-    preBuild.dependsOn generatePrefs
+}
+android.sourceSets.main.java.srcDirs += 'build/generated/java'
+preBuild.dependsOn generatePrefs
 
-    tasks.register("generateShortcuts") {
-        def out = file('build/generated/templateRes/xml/shortcuts.xml')
+def generateShortcuts = tasks.register("generateShortcuts") {
+    def templateFile = file('src/main/templates/xml/shortcuts.xml')
+    def out = file('build/generated/templateRes/xml/shortcuts.xml')
+    inputs.file(templateFile)
+    inputs.property('applicationId', android.defaultConfig.applicationId)
+    outputs.file(out)
+
+    doLast {
         out.getParentFile().exists() || out.getParentFile().mkdirs()
-        out.text = file('src/main/templates/xml/shortcuts.xml').text
+        out.text = templateFile.text
                 .replace('@@APPLICATION_ID@@', android.defaultConfig.applicationId)
     }
-    android.sourceSets.main.res.srcDirs += 'build/generated/templateRes'
-    preBuild.dependsOn generateShortcuts
 }
+android.sourceSets.main.res.srcDirs += 'build/generated/templateRes'
+preBuild.dependsOn generateShortcuts
 
 tasks.register('buildShellLoaderDebug', DefaultTask) {
     dependsOn ':shell-loader:assembleDebug'


### PR DESCRIPTION
## What

The `generatePrefs` / `generateShortcuts` code-generation tasks in `app/build.gradle` were registered inside `afterEvaluate` with **no declared inputs or outputs**, so Gradle could never mark them up-to-date:

- `generatePrefs` rewrote `Prefs.java` (`out.delete()` + `out.createNewFile()`) on every execution, forcing full javac recompilation of the app sources on every build
- The generation logic ran in the task **configuration closure** (not a `doLast`), i.e. at configuration time on every Gradle invocation, not only when the task executed
- `generateShortcuts` read `src/main/templates/xml/shortcuts.xml` and used `applicationId` without declaring either as an input

## Fix

- Move task registration out of `afterEvaluate` (the android extension is already configured at that point)
- Wrap the generation logic in `doLast` so it runs at execution time
- Declare `inputs.file` / `outputs.file`, plus an `applicationId` input property for `generateShortcuts`

## Verification

- Both tasks report **UP-TO-DATE** on the second run
- Generated `Prefs.java` content is unchanged
- `:app:compileDebugJavaWithJavac` builds successfully
