### PR TITLE
build(shell-loader): resolve COMMIT via providers.exec, not String.execute()

### DIFF
--- a/shell-loader/build.gradle
+++ b/shell-loader/build.gradle
@@ -48,7 +48,25 @@ android.defaultConfig.buildConfigField "String", "packageNotInstalledErrorText",
         \"After this you should download \\"termux-x11-ARCH-debug\\" or \\"termux-x11-universal-debug\\" artifact and install apk contained in this zip file.\""""
 android.defaultConfig.buildConfigField "String", "packageSignatureMismatchErrorText",
         "\"Signature verification of target application " + android.namespace + " failed.\\nPlease, reinstall both termux-x11 package and Termux:X11 application from the same source\""
-android.defaultConfig.buildConfigField "String", "COMMIT", "\"" + ("git rev-parse HEAD\n".execute().getText().trim() ?: (System.getenv('CURRENT_COMMIT') ?: "NO_COMMIT")) + "\""
+// Resolve the commit hash with providers.exec: it is the
+// configuration-cache-compatible way to run an external process at
+// configuration time. Plain String.execute() breaks configuration-cache
+// storage (failing the build when the cache is enabled) and also crashes
+// the configuration phase outright when git is not installed.
+def resolveGitCommit = { ->
+    try {
+        def execOut = providers.exec {
+            commandLine 'git', 'rev-parse', 'HEAD'
+            isIgnoreExitValue = true
+        }
+        def out = execOut.standardOutput.asText.get().trim()
+        return (execOut.result.get().exitValue == 0 && !out.isEmpty()) ? out : null
+    } catch (Exception ignored) {
+        return null
+    }
+}
+def vectrasCommit = resolveGitCommit() ?: (System.getenv('CURRENT_COMMIT') ?: "NO_COMMIT")
+android.defaultConfig.buildConfigField "String", "COMMIT", "\"" + vectrasCommit + "\""
 
 tasks.register('copyDebugApkToAssets', Copy) {
     from layout.buildDirectory.dir("outputs/apk/debug")


### PR DESCRIPTION
## What

`shell-loader/build.gradle:51` resolves the `COMMIT` BuildConfig field by running `"git rev-parse HEAD".execute()` at configuration time. Two problems with that:

1. **Configuration-cache violation** — with the configuration cache enabled, Gradle refuses to store the configuration: `external process started 'git rev-parse HEAD' during configuration time is unsupported`, and the build fails.
2. **Fragile** — `String.execute()` throws when `git` is not installed, crashing the whole configuration phase instead of falling back.

## Fix

Use `providers.exec`, the configuration-cache-compatible API for running an external process at configuration time. The fallback chain is preserved: git output → `CURRENT_COMMIT` env → `NO_COMMIT`.

## Verification

`:app:compileDebugJavaWithJavac --configuration-cache` builds successfully and stores the configuration cache entry (previously the storage failed with the git-execute violation).

## Note (pre-existing, out of scope)

`shell-loader/build.gradle:4-5` reads `project(':app').android.signingConfigs` at configuration time, which fails with `Could not get unknown property 'android' for project ':app'` when `:shell-loader` is built standalone under configure-on-demand. This exists on master and is unrelated to this change; the full `:app` build path (what CI runs) is unaffected.
