### PR TITLE
build: drop unused kotlin-gradle-plugin classpath (AGP 9 built-in Kotlin)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext {
-        kotlin_version = '2.3.10'
-    }
     repositories {
         mavenCentral()
         google()
@@ -10,7 +7,6 @@ buildscript {
 
     dependencies {
         classpath libs.gradle
-        classpath libs.kotlin.gradle.plugin
         // Android Gradle plugin
         // Add other classpaths like Google Services and Firebase Crashlytics if needed here.
         classpath libs.google.services  // assuming you need it for your project


### PR DESCRIPTION
## What

`ZoomImageView.kt` is compiled by AGP 9's **built-in Kotlin support** (visible in `app/build/intermediates/built_in_kotlinc/`) — no `kotlin-android` plugin is applied, and AGP 9 explicitly rejects that plugin if applied ("no longer required for Kotlin support since AGP 9.0").

That makes the `kotlin-gradle-plugin` classpath in the root `buildscript` block unnecessary, and the `kotlin_version = '2.3.10'` ext is dead config (mismatched with the version catalog's `kotlinGradlePlugin = "2.4.10"`, referenced nowhere).

## Fix

- Remove `classpath libs.kotlin.gradle.plugin` from `build.gradle`
- Remove the dead `kotlin_version` ext

The version catalog entry is kept — it's still referenced by the buildscript classpath resolution machinery.

## Verification

- `:app:compileDebugJavaWithJavac` builds successfully
- `ZoomImageView.class` is still produced by `built_in_kotlinc` (built-in Kotlin compilation is unaffected)
