### PR TITLE
ci: harden workflows against supply-chain and resource risks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,11 +3,14 @@ name: Android CI
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
     environment: BuildAPK
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v4
@@ -64,7 +67,7 @@ jobs:
         path: app/build/outputs/apk/release/app-release.apk
 
     - name: Update Alpha Release
-      uses: andelf/nightly-release@main
+      uses: andelf/nightly-release@5834076edc55cc05975561c9722043f072ac5c26
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -15,10 +15,14 @@ concurrency:
   group: pr-build-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     environment: PRBuild
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Four small hardening fixes to the CI workflows and Dependabot config:

### 1. Pin `andelf/nightly-release` to a commit SHA

`android.yml` uses `andelf/nightly-release@main` — a mutable branch ref on a personal-fork action, running with `GITHUB_TOKEN` attached. If the action's `main` branch is force-pushed, the next run silently executes whatever is there.

Pinned to `5834076edc55cc05975561c9722043f072ac5c26` (current `main` at time of writing).

### 2. Add `permissions:` blocks

Neither workflow declared a `permissions:` block, so `GITHUB_TOKEN` gets the default broad scope:

- `android.yml` (release job): `contents: write` — needed to create releases
- `pr-build.yml` (build-only): `contents: read` — least privilege

### 3. Add `timeout-minutes: 60`

A hung Gradle build currently burns runner minutes indefinitely. Both jobs now time out after 60 minutes.

### 4. Add `github-actions` ecosystem to Dependabot

`dependabot.yml` only covered `gradle`, so action versions were never auto-bumped (relevant given the `@main` pin above). Added a `github-actions` entry with the same weekly schedule.

## Verification

YAML structure verified for both workflows; no changes to build steps.
